### PR TITLE
RINEX fixes

### DIFF
--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -2386,6 +2386,17 @@ namespace gpstk
 
          // 'old-style' type: Let's change it to 'new style'.
       if( newType.size() == 2 )
+      if (version < 3.0)
+      {
+         // Use mappings instead to find reassigned observation types
+         if (mapSysR2toR3ObsID.count("G") == 0 || mapSysR2toR3ObsID.at("G").count(newType) == 0)
+         {
+            InvalidRequest exc("Missing observation type.");
+            GPSTK_THROW(exc);
+         }
+         newType = mapSysR2toR3ObsID.at("G").at(newType).asString();
+      }
+      else
       {
          if( newType == "C1" ) newType = "C1C";
          else if( newType == "P1" ) newType = "C1P";

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -1314,7 +1314,9 @@ namespace gpstk
 
          valid |= validSystemScaleFac;
       }
-      else if(label == hsSystemPhaseShift) ///< "SYS / PHASE SHIFT"    R3.01
+      // R3.01: "SYS / PHASE SHIFTS"
+      // R3.02: "SYS / PHASE SHIFT" (why?!)
+      else if(label == hsSystemPhaseShift || label == hsSystemPhaseShift + "S")
       {
          RinexSatID sat;
             // system

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -1720,10 +1720,9 @@ namespace gpstk
             // assume that file creator knew what he was doing,
             // and use TimeSystem::GPS by default
             strm.timesystem = TimeSystem::GPS;
-            firstObs.setTimeSystem(TimeSystem::BDT);
+            firstObs.setTimeSystem(TimeSystem::GPS);
          }
-         else
-         {
+         else {
             FFStreamError e("Unknown file system type");
             GPSTK_THROW(e);
          }

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -1713,10 +1713,12 @@ namespace gpstk
             strm.timesystem = TimeSystem::BDT;
             firstObs.setTimeSystem(TimeSystem::BDT);
          }
-         else if(fileSysSat.system == SatID::systemMixed)
-         {
-            FFStreamError e("TimeSystem in MIXED files must be given by first obs");
-            GPSTK_THROW(e);
+         else if(fileSysSat.system == SatID::systemMixed) {
+            // Though it violates the standard,
+            // assume that file creator knew what he was doing,
+            // and use TimeSystem::GPS by default
+            strm.timesystem = TimeSystem::GPS;
+            firstObs.setTimeSystem(TimeSystem::BDT);
          }
          else
          {

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.hpp
@@ -235,8 +235,8 @@ namespace gpstk
 
             // NB 19Jun2013 MGEX data does not include GLONASS SLOT
             // and GLONASS COD/PHS/BIS records
-         allValid301            = 0x041205AB, ///< RINEX 3.01
-         allValid302            = 0x041205AB  ///< RINEX 3.02
+         allValid301            = 0x001205CB, ///< RINEX 3.01
+         allValid302            = 0x001205CB  ///< RINEX 3.02
       };
    
 #ifndef SWIG // nested structs/classes not supported by SWIG


### PR DESCRIPTION
This addresses a few common pitfalls encountered when processing RINEX data.
1) Better conformance with RINEX 3.0+ specifications.
2) Backward compatibility with RINEX 2.0 observation types (L1, L2, ...) when processing old-style files.
