### PR TITLE
Allow client-code to treat SatPass as constant

### DIFF
--- a/core/lib/FileHandling/SP3/SP3Header.hpp
+++ b/core/lib/FileHandling/SP3/SP3Header.hpp
@@ -78,9 +78,10 @@ namespace gpstk
       };
 
          /// constructor
-      SP3Header() : version(undefined), numberOfEpochs(0),
+      SP3Header() : version(undefined),
+                    allowSP3aEvents(false), numberOfEpochs(0),
                     system(1, SP3SatID::systemGPS), timeSystem(TimeSystem::Any),
-                    basePV(0.0), baseClk(0.0), allowSP3aEvents(false)
+                    basePV(0.0), baseClk(0.0)
       {}
 
          /// destructor

--- a/core/lib/Utilities/StringUtils.hpp
+++ b/core/lib/Utilities/StringUtils.hpp
@@ -2813,7 +2813,7 @@ namespace gpstk
             size_t len = aStr.length();
             rv.reserve(len);
 
-            for (int i = 0; i < len; i++)
+            for (size_t i = 0; i < len; i++)
             {
                char c = aStr[i];
                if (c > 31 && c < 127)  // Handle printable ASCII characters

--- a/ext/lib/Geomatics/SatPass.cpp
+++ b/ext/lib/Geomatics/SatPass.cpp
@@ -581,7 +581,7 @@ catch(Exception& e) { GPSTK_RETHROW(e); }
 
 // -------------------------- get and set routines ----------------------------
 // NB may be used as rvalue or lvalue
-double& SatPass::data(unsigned int i, string type) throw(Exception)
+double& SatPass::data(unsigned int i, const string &type) throw(Exception)
 {
    if(i >= spdvector.size()) {
       Exception e("Invalid index in data() " + asString(i));

--- a/ext/lib/Geomatics/SatPass.hpp
+++ b/ext/lib/Geomatics/SatPass.hpp
@@ -245,8 +245,8 @@ public:
    /// @return n>=0 if data was added successfully, n is the index of the new data
    ///        -1 if a gap is found (no data is added),
    ///        -2 if time tag is out of order (no data is added)
-   int addData(const Epoch tt, std::vector<std::string>& obstypes,
-                                  std::vector<double>& data) throw(Exception);
+   int addData(const Epoch tt, const std::vector<std::string>& obstypes,
+                               const std::vector<double>& data) throw(Exception);
 
    /// Add vector of data, identified by obstypes (same as used in c'tor) at tt,
    /// Flag, lli and ssi are set using input (parallel to data).
@@ -285,11 +285,17 @@ public:
    /// Access the status; l-value may be assigned SP.status() = 1;
    int& status(void) throw() { return Status; }
 
+   /// Access the (constant) data for one obs type at one index
+   /// @param  i    index of the data of interest
+   /// @param  type observation type (e.g. "L1") of the data of interest
+   /// @return the data of the given type at the given index
+   double data(unsigned int i, const std::string& type) const throw(Exception);
+
    /// Access the data for one obs type at one index, as either l-value or r-value
    /// @param  i    index of the data of interest
    /// @param  type observation type (e.g. "L1") of the data of interest
    /// @return the data of the given type at the given index
-   double& data(unsigned int i, const std::string &type) throw(Exception);
+   double& data(unsigned int i, const std::string& type) throw(Exception);
 
    /// Access the time offset from the nominal time (i.e. timetag) at one index
    /// (epoch), as either l-value or r-value
@@ -301,13 +307,13 @@ public:
    /// @param  i    index of the data of interest
    /// @param  type observation type (e.g. "L1") of the data of interest
    /// @return the LLI of the given type at the given index
-   unsigned short& LLI(unsigned int i, std::string type) throw(Exception);
+   unsigned short& LLI(unsigned int i, const std::string& type) throw(Exception);
 
    /// Access the ssi for one obs type at one index, as either l-value or r-value
    /// @param  i    index of the data of interest
    /// @param  type observation type (e.g. "L1") of the data of interest
    /// @return the SSI of the given type at the given index
-   unsigned short& SSI(unsigned int i, std::string type) throw(Exception);
+   unsigned short& SSI(unsigned int i, const std::string& type) throw(Exception);
 
    // -------------------------------- set only --------------------------------
    /// change the maximum time gap (in seconds) allowed within any SatPass
@@ -338,16 +344,19 @@ public:
 
    /// get the list of obstypes
    /// @return the vector of strings giving RINEX obs types
-   std::vector<std::string> getObsTypes(void) throw() {
+   std::vector<std::string> getObsTypes(void) const throw() {
       std::vector<std::string> v;
-      for(unsigned i=0; i<labelForIndex.size(); i++) v.push_back(labelForIndex[i]);
+      std::map<unsigned int, std::string>::const_iterator li;
+      for (li=labelForIndex.begin(); li!=labelForIndex.end(); ++li) {
+            v.push_back(li->second);
+      }
       return v;
    }
 
    /// get the flag at one index
    /// @param  i    index of the data of interest
    /// @return the flag for the given index
-   unsigned short getFlag(unsigned int i) throw(Exception);
+   unsigned short getFlag(unsigned int i) const throw(Exception);
 
    /// @return the earliest time (full, including toffset) in this SatPass data
    Epoch getFirstTime(void) const throw();
@@ -398,23 +407,24 @@ public:
    /// @param  type1 observation type (e.g. "P1") of the data of interest
    /// @param  type2 observation type (e.g. "C1") of the data of interest
    /// @return the data of the given type at the given index
-   double data(unsigned int i, std::string type1, std::string type2) throw(Exception);
+   double data(unsigned int i, const std::string& type1,
+               const std::string& type2) const throw(Exception);
 
    /// Access the LLI for either of two obs type at one index, as r-value only
    /// @param  i     index of the data of interest
    /// @param  type1 observation type (e.g. "P1") of the data of interest
    /// @param  type2 observation type (e.g. "C1") of the data of interest
    /// @return the LLI of the given type at the given index
-   unsigned short LLI(unsigned int i, std::string type1, std::string type2)
-      throw(Exception);
+   unsigned short LLI(unsigned int i, const std::string& type1,
+                      const std::string& type2) const throw(Exception);
 
    /// Access the ssi for either of two obs type at one index, as r-value only
    /// @param  i     index of the data of interest
    /// @param  type1 observation type (e.g. "P2") of the data of interest
    /// @param  type2 observation type (e.g. "C2") of the data of interest
    /// @return the SSI of the given type at the given index
-   unsigned short SSI(unsigned int i, std::string type1, std::string type2)
-      throw(Exception);
+   unsigned short SSI(unsigned int i, const std::string& type1,
+                      const std::string& type2) const throw(Exception);
 
    /// Test whether the object has obstype type
    /// @return true if this obstype was passed to the c'tor (i.e. is in indexForLabel)

--- a/ext/lib/Geomatics/SatPass.hpp
+++ b/ext/lib/Geomatics/SatPass.hpp
@@ -103,7 +103,7 @@ protected:
             data.resize(right.data.size());
             lli.resize(right.lli.size());
             ssi.resize(right.ssi.size());
-            int i;
+            unsigned i;
             for(i=0; i<right.data.size(); i++) data[i] = right.data[i];
             for(i=0; i<right.lli.size(); i++) lli[i] = right.lli[i];
             for(i=0; i<right.ssi.size(); i++) ssi[i] = right.ssi[i];
@@ -289,7 +289,7 @@ public:
    /// @param  i    index of the data of interest
    /// @param  type observation type (e.g. "L1") of the data of interest
    /// @return the data of the given type at the given index
-   double& data(unsigned int i, std::string type) throw(Exception);
+   double& data(unsigned int i, const std::string &type) throw(Exception);
 
    /// Access the time offset from the nominal time (i.e. timetag) at one index
    /// (epoch), as either l-value or r-value
@@ -340,7 +340,7 @@ public:
    /// @return the vector of strings giving RINEX obs types
    std::vector<std::string> getObsTypes(void) throw() {
       std::vector<std::string> v;
-      for(int i=0; i<labelForIndex.size(); i++) v.push_back(labelForIndex[i]);
+      for(unsigned i=0; i<labelForIndex.size(); i++) v.push_back(labelForIndex[i]);
       return v;
    }
 
@@ -357,7 +357,7 @@ public:
 
    /// @return the earliest time of good data in this SatPass data
    Epoch getFirstGoodTime(void) const throw() {
-      for(int j=0; j<spdvector.size(); j++) if(spdvector[j].flag & OK) {
+      for(unsigned j=0; j<spdvector.size(); j++) if(spdvector[j].flag & OK) {
          return time(j);
       }
       return CommonTime::END_OF_TIME;
@@ -426,7 +426,7 @@ public:
    /// Access the obstypes (as strings)
    std::vector<std::string> getObstypes(void) {
       std::vector<std::string> ots;
-      for(int i=0; i<labelForIndex.size(); i++)
+      for(unsigned i=0; i<labelForIndex.size(); i++)
          ots.push_back(labelForIndex[i]);
       return ots;
    }
@@ -447,8 +447,8 @@ public:
    {
       int count = countForTime(tt);
       if(count < 0) return -1;
-      for(int i=0; i<spdvector.size(); i++)
-         if(count == spdvector[i].ndt) return i;
+      for(unsigned i=0; i<spdvector.size(); i++)
+         if(count == (int)spdvector[i].ndt) return i;
       return -1;
    }
 
@@ -622,7 +622,7 @@ public:
          << " to " << printTime(getLastTime(),fmt)
          << " obs:";
       std::vector<std::string> ots = getObstypes();
-      for(int i=0; i<ots.size(); i++) os << " " << ots[i];
+      for(unsigned i=0; i<ots.size(); i++) os << " " << ots[i];
       return os.str();
    }
    /// Dump all the data in the pass, one line per timetag.


### PR DESCRIPTION
Various methods within SatPass have changed since gpstk-2.6 which break client code which attempts to treat SatPass as a constant. Query methods like data() force the client to receive a non-constant reference even when they need read-only access to observation data.
Various patches have been added to SatPass which improve support for read-only access by clients using "const SatPass" objects. Also, various getter methods have been adjusted to take const std::string& to avoid unnecessary copying of string parameters that are not modified within GPSTk.