### PR TITLE
Operating with common std::iostream instead of only file streams

### DIFF
--- a/core/lib/FileHandling/FFStream.cpp
+++ b/core/lib/FileHandling/FFStream.cpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -85,6 +85,13 @@ namespace gpstk
       open(fn, mode);
    }
 
+   FFStream ::
+   FFStream( std::basic_iostream<char>& anotherStream )
+         : recordNumber(0)
+   {
+     std::basic_iostream<char>::init(anotherStream.rdbuf());
+     clear();
+   }
 
    void FFStream ::
    open( const std::string& fn,
@@ -105,7 +112,9 @@ namespace gpstk
          // classes typically will want to do their initialization
          // AFTER the parent.
       init(fn, mode);
-      std::fstream::open(fn, mode);
+      fileStream.open(fn, mode);
+      std::basic_iostream<char>::init(fileStream.rdbuf());
+      std::basic_iostream<char>::setstate(fileStream.rdstate());
    }  // End of method 'FFStream::open()'
 
 
@@ -123,7 +132,7 @@ namespace gpstk
    isFFStream(std::istream& i)
    {
       try
-      { 
+      {
          (void)dynamic_cast<FFStream&>(i);
       }
       catch(...)
@@ -275,7 +284,7 @@ namespace gpstk
 
 
 
-      // the crazy double try block is so that no gpstk::Exception throws 
+      // the crazy double try block is so that no gpstk::Exception throws
       // get masked, allowing all exception information (line numbers, text,
       // etc) to be retained.
    void FFStream ::
@@ -309,7 +318,7 @@ namespace gpstk
             setstate(std::ios::failbit);
             conditionalThrow();
          }
-         catch (gpstk::StringUtils::StringException& e)  
+         catch (gpstk::StringUtils::StringException& e)
          {
             e.addText("In record " +
                       gpstk::StringUtils::asString(recordNumber));
@@ -320,7 +329,7 @@ namespace gpstk
             recordNumber = initialRecordNumber;
             setstate(std::ios::failbit);
             conditionalThrow();
-         } 
+         }
             // catches some errors we can encounter
          catch (FFStreamError& e)
          {
@@ -378,5 +387,16 @@ namespace gpstk
    }  // End of method 'FFStream::tryFFStreamPut()'
 
 
+   void FFStream::close()
+   {
+     if (fileStream && fileStream.is_open())
+       fileStream.close();
+   }
 
+   bool FFStream::is_open()
+   {
+     if(fileStream)
+       return fileStream.is_open();
+     return true;
+   }
 }  // End of namespace gpstk

--- a/core/lib/FileHandling/FFStream.hpp
+++ b/core/lib/FileHandling/FFStream.hpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -118,7 +118,7 @@ namespace gpstk
        * @warning When using open(), the internal header data of the stream
        * is not guaranteed to be retained.
        */
-   class FFStream : public std::fstream
+   class FFStream : public std::basic_iostream<char>
    {
    public:
          /// Default constructor, initialize internal data
@@ -140,6 +140,12 @@ namespace gpstk
           * @param[in] mode file open mode (std::ios)
           */
       FFStream( const std::string& fn, std::ios::openmode mode=std::ios::in );
+
+         /** Construction from another stream for decoration
+          *
+          * @param anotherStream
+          */
+      FFStream( std::basic_iostream<char>& anotherStream);
 
          /**
           * Overrides fstream::open so derived classes can make appropriate
@@ -170,6 +176,9 @@ namespace gpstk
          /// Check if the input stream is the kind of RinexObsStream
       static bool isFFStream(std::istream& i);
 
+      virtual void close();
+      virtual bool is_open();
+
          /// This stores the most recently thrown exception.
       FFStreamError mostRecentException;
 
@@ -185,6 +194,7 @@ namespace gpstk
 
    protected:
 
+      std::fstream fileStream; // used only in file system case;
 
          /// Encapsulates shared try/catch blocks for all file types
          /// to hide std::exception.

--- a/core/lib/FileHandling/FFTextStream.cpp
+++ b/core/lib/FileHandling/FFTextStream.cpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -73,6 +73,12 @@ namespace gpstk
       init();
    }
 
+   FFTextStream ::
+   FFTextStream(std::basic_iostream<char>& anotherStream)
+         : FFStream(anotherStream)
+   {
+      init();
+   };
 
    void FFTextStream ::
    open( const char* fn,

--- a/core/lib/FileHandling/FFTextStream.hpp
+++ b/core/lib/FileHandling/FFTextStream.hpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -82,6 +82,12 @@ namespace gpstk
           */
       FFTextStream( const std::string& fn,
                     std::ios::openmode mode=std::ios::in );
+
+         /** Common constructor.
+          *
+          * @param anotherStream stream.
+          */
+      FFTextStream( std::basic_iostream<char>& anotherStream );
 
          /// Overrides open to reset the line number.
       virtual void open( const char* fn,

--- a/core/lib/FileHandling/RINEX3/Rinex3NavStream.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavStream.cpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -57,6 +57,12 @@ namespace gpstk
       init();
    }
 
+   Rinex3NavStream ::
+   Rinex3NavStream(std::basic_iostream<char>& anotherStream)
+         : FFTextStream(anotherStream)
+   {
+     init();
+   }
 
    Rinex3NavStream ::
    ~Rinex3NavStream()
@@ -66,16 +72,16 @@ namespace gpstk
 
    void Rinex3NavStream ::
    open(const char* fn, std::ios::openmode mode)
-   { 
-      FFTextStream::open(fn, mode); 
+   {
+      FFTextStream::open(fn, mode);
       init();
    }
 
 
    void Rinex3NavStream ::
    init()
-   { 
-      headerRead = false; 
+   {
+      headerRead = false;
       header = Rinex3NavHeader();
    }
 }

--- a/core/lib/FileHandling/RINEX3/Rinex3NavStream.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavStream.hpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -62,21 +62,26 @@ namespace gpstk
    public:
          /// Default constructor
       Rinex3NavStream();
-      
-         /** Constructor 
+
+         /** Constructor
           * Opens a file named \a fn using ios::openmode \a mode.
           */
       Rinex3NavStream(const char* fn, std::ios::openmode mode=std::ios::in);
-      
+
+         /** Constructor
+          * Operates with \a anotherStream as navigation stream.
+          */
+      Rinex3NavStream(std::basic_iostream<char>& anotherStream);
+
          /// Destructor
       virtual ~Rinex3NavStream();
-      
+
          /// overrides open to reset the header
       virtual void open(const char* fn, std::ios::openmode mode);
 
          /// RINEX NAV header for this file.
       Rinex3NavHeader header;
-     
+
          /// Flag showing whether or not the header has been read.
       bool headerRead;
 

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsStream.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsStream.cpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -67,6 +67,12 @@ namespace gpstk
       init();
    }
 
+   Rinex3ObsStream ::
+   Rinex3ObsStream( std::basic_iostream<char>& anotherStream )
+         : FFTextStream(anotherStream)
+   {
+     init();
+   }
 
    Rinex3ObsStream ::
    ~Rinex3ObsStream()

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsStream.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsStream.hpp
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with GPSTk; if not, write to the Free Software Foundation,
 //  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110, USA
-//  
+//
 //  Copyright 2004, The University of Texas at Austin
 //
 //============================================================================
@@ -23,13 +23,13 @@
 //============================================================================
 //
 //This software developed by Applied Research Laboratories at the University of
-//Texas at Austin, under contract to an agency or agencies within the U.S. 
+//Texas at Austin, under contract to an agency or agencies within the U.S.
 //Department of Defense. The U.S. Government retains all rights to use,
-//duplicate, distribute, disclose, or release this software. 
+//duplicate, distribute, disclose, or release this software.
 //
-//Pursuant to DoD Directive 523024 
+//Pursuant to DoD Directive 523024
 //
-// DISTRIBUTION STATEMENT A: This software has been approved for public 
+// DISTRIBUTION STATEMENT A: This software has been approved for public
 //                           release, distribution is unlimited.
 //
 //=============================================================================
@@ -81,6 +81,12 @@ namespace gpstk
           */
       Rinex3ObsStream( const std::string fn,
                        std::ios::openmode mode = std::ios::in );
+
+         /** Common constructor.
+          *
+          * @param[in] anotherStream the RINEX stream to open
+          */
+      Rinex3ObsStream( std::basic_iostream<char>& anotherStream );
 
          /// Destructor
       virtual ~Rinex3ObsStream();


### PR DESCRIPTION
FFStream inheritance changed from std::fstream to std::iostream with backward compatibility, that leads to a couple of features:
  - possibility to use streams not connected to filesystem in cases when information comes from network
  - writing unit tests without work with filesystem, simple std::stringstream can be used