### PR TITLE
Fix issue #27 by linking against regex library in WIN32 && MINGW platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,13 @@ endif()
 # GPSTk shared-object library (e.g. libgpstk.so) build target
 add_library( gpstk ${STADYN} ${GPSTK_SRC_FILES} ${GPSTK_INC_FILES} )
 
+if (WIN32) #Windows Linker Options
+  if (MINGW)
+    target_link_libraries(gpstk regex)
+  endif()
+endif()
+
+
 # GPSTk library install target
 install( TARGETS gpstk DESTINATION "${CMAKE_INSTALL_LIBDIR}" EXPORT "${EXPORT_TARGETS_FILENAME}" )
 


### PR DESCRIPTION
I get linker errors to undefined functions from regex library when compiling on Mingw/MSys2.

```
../../../libgpstk.a(UnixTime.cpp.obj):UnixTime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x5d): undefined reference to `regcomp'
../../../libgpstk.a(UnixTime.cpp.obj):UnixTime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x8f): undefined reference to `regerror'
../../../libgpstk.a(UnixTime.cpp.obj):UnixTime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x9e): undefined reference to `regfree'
../../../libgpstk.a(UnixTime.cpp.obj):UnixTime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x2a7): undefined reference to `regexec'
../../../libgpstk.a(UnixTime.cpp.obj):UnixTime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIlEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x435): undefined reference to `regfree'
../../../libgpstk.a(ANSITime.cpp.obj):ANSITime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x5d): undefined reference to `regcomp'
../../../libgpstk.a(ANSITime.cpp.obj):ANSITime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x8f): undefined reference to `regerror'
../../../libgpstk.a(ANSITime.cpp.obj):ANSITime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x9e): undefined reference to `regfree'
../../../libgpstk.a(ANSITime.cpp.obj):ANSITime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x2a7): undefined reference to `regexec'
../../../libgpstk.a(ANSITime.cpp.obj):ANSITime.cpp:(.text$_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_[_ZN5gpstk11StringUtils14formattedPrintIxEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS7_S9_S9_T_]+0x436): undefined reference to `regfree'
```

This is the fix for it.