### PR TITLE
BDS GEO satellite ephemeris problem.

### DIFF
--- a/core/lib/FileHandling/SP3/SP3Header.cpp
+++ b/core/lib/FileHandling/SP3/SP3Header.cpp
@@ -170,7 +170,7 @@ namespace gpstk
              }
              else
              {
-                FFStreamError e("Unknown 1st char in line " + asString(i) + ": "
+                FFStreamError e("Unknown 1st char in line " + asString(lineCount) + ": "
                    + string(1, line[0]));
                 GPSTK_THROW(e);
              }

--- a/core/lib/GNSSEph/BDSEphemeris.cpp
+++ b/core/lib/GNSSEph/BDSEphemeris.cpp
@@ -160,7 +160,7 @@ namespace gpstk
          // If the PRN ID is greatet than 5, assume this
          // is a MEO or IGSO SV and use the standard OrbitEph
          // version of svXvt
-      if (satID.id>5) return(OrbitEph::svXvt(t));
+      if (satID.id>5 && satID.id != 59) return(OrbitEph::svXvt(t));
 
          // If PRN ID is in the range 1-5, treat this as a GEO
          // 

--- a/core/lib/GNSSEph/OrbitEphStore.cpp
+++ b/core/lib/GNSSEph/OrbitEphStore.cpp
@@ -73,8 +73,24 @@ namespace gpstk
          if(onlyHealthy && !eph->isHealthy())
             GPSTK_THROW(InvalidRequest("Not healthy"));
 
-         // compute the position, velocity and time
-         Xvt sv = eph->svXvt(t);
+          Xvt sv;
+          const BDSEphemeris *bdsEph = NULL;
+          // compute the position, velocity and time
+          switch (eph->satID.system)
+          {
+             // BDS: Prn 1~5 and 59 satellites in BDS are GEO type. 
+             // Special treatments are needed.
+             // ref. http://www.csno-tarc.cn/system/constellation&ce=english
+          case SatID::systemBeiDou:
+             bdsEph = dynamic_cast<const BDSEphemeris *>(eph);
+             sv = bdsEph->svXvt(t);
+             break;
+             // GPS, GAL, QZSS 
+          default:
+             sv = eph->svXvt(t);
+             break;
+          }
+
          return sv;
       }
       catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }


### PR DESCRIPTION
GPSTk has provided algorithm(`BDSEphemeris::svXvt`) for BDS GEO satellite ephemeris  interpolate, but `BDSEphemerisStore, Rinex3EphemerisStore and OrbitEphStore` never make a call for `BDSEphemeris::svXvt`, while the BDS GEO satellites(1~5, 59) are comming through. So I modefied OrbitEphStore to get this problem solved.