### PR TITLE
Add SWIG wrappers for functions converting to GPSEphemeris.

### DIFF
--- a/swig/gpstk.i
+++ b/swig/gpstk.i
@@ -161,6 +161,7 @@ using namespace gpstk;
 // =============================================================
 // Renames on a few commonly used operators
 %rename (toEngEphemeris) *::operator EngEphemeris() const;
+%rename (toGPSEphemeris) *::operator GPSEphemeris() const;
 %rename (toGalEphemeris) *::operator GalEphemeris() const;
 %rename (toGloEphemeris) *::operator GloEphemeris() const;
 %rename (toAlmOrbit) *::operator AlmOrbit() const;


### PR DESCRIPTION
As far as I can tell, EngEphemeris is deprecated and no longer compatible with the GPSEphemerisStore or related implementations. This change allows Python creation of GPSEphemeris objects from RINEX NAV files for use with a GPSEphemerisStore.