### PR TITLE
C++17 (replace throw with noexcept)

### DIFF
--- a/core/lib/AppFrame/BasicFramework.cpp
+++ b/core/lib/AppFrame/BasicFramework.cpp
@@ -53,7 +53,7 @@ namespace gpstk
 
    BasicFramework :: BasicFramework( const string& applName,
                                      const string& applDesc )
-      throw()
+      noexcept
          : debugLevel(0),
            verboseLevel(0),
            exitCode(0),
@@ -69,7 +69,7 @@ namespace gpstk
    bool BasicFramework :: initialize( int argc,
                                       char *argv[],
                                       bool pretty )
-      throw()
+      noexcept
    {
 
          // Creating the parser here ensures that all the subclasses'
@@ -122,7 +122,7 @@ namespace gpstk
 
 
    bool BasicFramework :: run()
-      throw()
+      noexcept
    {
 
       try

--- a/core/lib/AppFrame/BasicFramework.hpp
+++ b/core/lib/AppFrame/BasicFramework.hpp
@@ -109,7 +109,7 @@ namespace gpstk
           */
       BasicFramework( const std::string& applName,
                       const std::string& applDesc )
-         throw();
+         noexcept;
 
 
          /// Destructor.
@@ -130,7 +130,7 @@ namespace gpstk
       virtual bool initialize( int argc,
                                char *argv[],
                                bool pretty = true )
-         throw();
+         noexcept;
 
 
          /** Run the program. Processes only once (refer to subclasses
@@ -138,7 +138,7 @@ namespace gpstk
           *
           * @return false if an exception occurred
           */
-      bool run() throw();
+      bool run() noexcept;
 
 
          /** A place to store the exit code for the application.

--- a/core/lib/AppFrame/InOutFramework.hpp
+++ b/core/lib/AppFrame/InOutFramework.hpp
@@ -78,7 +78,7 @@ namespace gpstk
           */
       InOutFramework( const std::string& applName,
                       const std::string& applDesc )
-            throw()
+            noexcept
             : LoopedFramework(applName, applDesc)
       {};
 
@@ -90,7 +90,7 @@ namespace gpstk
       bool initialize( int argc,
                        char *argv[],
                        bool pretty = true )
-         throw()
+         noexcept
       {
          using std::ios;
 

--- a/core/lib/AppFrame/LoopedFramework.hpp
+++ b/core/lib/AppFrame/LoopedFramework.hpp
@@ -75,7 +75,7 @@ namespace gpstk
           */
       LoopedFramework(const std::string& applName,
                       const std::string& applDesc)
-            throw()
+            noexcept
             : BasicFramework(applName, applDesc), timeToDie(false)
       { }
 

--- a/core/lib/ClockModel/ClockModel.hpp
+++ b/core/lib/ClockModel/ClockModel.hpp
@@ -60,7 +60,7 @@ namespace gpstk
    class ClockModel
    {
    public:
-      ClockModel() throw() {};
+      ClockModel() noexcept {};
 
       virtual double getOffset(const gpstk::CommonTime& t) const = 0;
 

--- a/core/lib/ClockModel/EpochClockModel.hpp
+++ b/core/lib/ClockModel/EpochClockModel.hpp
@@ -66,7 +66,7 @@ namespace gpstk
             : ObsClockModel(sigma, elmask, mode), valid(false), clkc(0){}
 #pragma clang diagnostic pop
       virtual double getOffset(const gpstk::CommonTime& t) const
-         throw(gpstk::InvalidArgumentException) 
+         noexcept(false) 
       {
          if (t!=time)
          {
@@ -77,7 +77,7 @@ namespace gpstk
       };
 
       virtual bool isOffsetValid(const gpstk::CommonTime& t) const 
-         throw(gpstk::InvalidArgumentException)
+         noexcept(false)
       {
          if (t!=time) 
          {
@@ -91,12 +91,12 @@ namespace gpstk
          // An unchecked accessor for programs that don't need the generic
          // interface
       double getOffset() const
-         throw() {return clkc;};
+         noexcept {return clkc;};
 
       bool isOffsetValid() const 
-         throw() {return valid;};
+         noexcept {return valid;};
 
-      virtual void addEpoch(const ORDEpoch& oe) throw(gpstk::InvalidValue)
+      virtual void addEpoch(const ORDEpoch& oe) noexcept(false)
       {
          gpstk::Stats<double> stat = simpleOrdClock(oe);
          clkc = stat.Average();

--- a/core/lib/ClockModel/LinearClockModel.cpp
+++ b/core/lib/ClockModel/LinearClockModel.cpp
@@ -49,7 +49,7 @@ namespace gpstk
 {
    using namespace std;
 
-   void LinearClockModel::reset() throw()
+   void LinearClockModel::reset() noexcept
    {
       startTime = gpstk::CommonTime::END_OF_TIME;
       endTime = gpstk::CommonTime::BEGINNING_OF_TIME;
@@ -60,7 +60,7 @@ namespace gpstk
    }
 
    void LinearClockModel::addEpoch(const ORDEpoch& oe)
-      throw(gpstk::InvalidValue)
+      noexcept(false)
    {
       ORDEpoch::ORDMap::const_iterator itr;
       const gpstk::CommonTime t=oe.time;
@@ -137,7 +137,7 @@ namespace gpstk
       }
    }
 
-   void LinearClockModel::dump(std::ostream& s, short detail) const throw()
+   void LinearClockModel::dump(std::ostream& s, short detail) const noexcept
    {
       s << "base: " << baseTime
         << ", start: " << startTime

--- a/core/lib/ClockModel/LinearClockModel.hpp
+++ b/core/lib/ClockModel/LinearClockModel.hpp
@@ -64,7 +64,7 @@ namespace gpstk
             :ObsClockModel(sigma, elmask, mode) {reset();};
 
       virtual double getOffset(const gpstk::CommonTime& t) const 
-         throw()
+         noexcept
       {
          if (!isOffsetValid(t))
             return 0;
@@ -72,16 +72,16 @@ namespace gpstk
             return clockModel.Slope()*(t-baseTime) + clockModel.Intercept();
       };
 
-      virtual bool isOffsetValid(const gpstk::CommonTime& t) const throw()
+      virtual bool isOffsetValid(const gpstk::CommonTime& t) const noexcept
       {return t >= startTime && t <= endTime && clockModel.N() > 1;};
 
          /// Add in the given ord to the clock model
-      virtual void addEpoch(const ORDEpoch& oe) throw(gpstk::InvalidValue);
+      virtual void addEpoch(const ORDEpoch& oe) noexcept(false);
 
          /// Reset the accumulated statistics on the clock
-      void reset() throw();
+      void reset() noexcept;
 
-      void dump(std::ostream& s, short detail=1) const throw();
+      void dump(std::ostream& s, short detail=1) const noexcept;
 
       friend std::ostream& operator<<(std::ostream& s, const LinearClockModel& r)
       { r.dump(s, 0); return s; };

--- a/core/lib/ClockModel/ORDEpoch.hpp
+++ b/core/lib/ClockModel/ORDEpoch.hpp
@@ -62,7 +62,7 @@ namespace gpstk
          /// defines a store for each SV's ord, indexed by prn
       typedef std::map<SatID, ObsRngDev> ORDMap;
 
-      ORDEpoch& removeORD(const SatID& svid) throw()
+      ORDEpoch& removeORD(const SatID& svid) noexcept
       {
          ORDMap::iterator i = ords.find(svid);
          if(i != ords.end())
@@ -70,7 +70,7 @@ namespace gpstk
          return *this;
       }
    
-      ORDEpoch& applyClockModel(const ClockModel& cm) throw()
+      ORDEpoch& applyClockModel(const ClockModel& cm) noexcept
       {
          if (cm.isOffsetValid(time))
          {
@@ -80,7 +80,7 @@ namespace gpstk
          return *this;
       }
 
-      ORDEpoch& removeOffset(const double offset) throw()
+      ORDEpoch& removeOffset(const double offset) noexcept
       {
          ORDMap::iterator i;
          for (i = ords.begin(); i != ords.end(); i++)
@@ -96,7 +96,7 @@ namespace gpstk
 
       friend std::ostream& operator<<(std::ostream& s, 
                                       const ORDEpoch& oe)
-         throw()
+         noexcept
       {
          s << "t=" << oe.time
            << " clk=" << oe.clockOffset << std::endl;

--- a/core/lib/ClockModel/ObsClockModel.cpp
+++ b/core/lib/ClockModel/ObsClockModel.cpp
@@ -54,7 +54,7 @@ namespace gpstk
 
 
    ObsClockModel::SvStatus ObsClockModel::getSvStatus(const SatID& svid) const
-      throw(gpstk::ObjectNotFound)
+      noexcept(false)
    {
       SvStatusMap::const_iterator i = status.find(svid);
       if(i == status.end())
@@ -70,7 +70,7 @@ namespace gpstk
 
 
    ObsClockModel& ObsClockModel::setSvModeMap(const SvModeMap& right)
-      throw()
+      noexcept
    {
       for(int prn = 1; prn <= gpstk::MAX_PRN; prn++)
          modes[SatID(prn, SatID::systemGPS)] = IGNORE;
@@ -83,7 +83,7 @@ namespace gpstk
 
 
    ObsClockModel::SvMode ObsClockModel::getSvMode(const SatID& svid) const
-      throw(gpstk::ObjectNotFound)
+      noexcept(false)
    {
       SvModeMap::const_iterator i = modes.find(svid);
       if(i == modes.end())
@@ -99,7 +99,7 @@ namespace gpstk
 
 
    gpstk::Stats<double> ObsClockModel::simpleOrdClock(const ORDEpoch& oe)
-      throw(gpstk::InvalidValue)
+      noexcept(false)
    {
       gpstk::Stats<double> stat;
       
@@ -167,7 +167,7 @@ namespace gpstk
       return stat;
    }
 
-   void ObsClockModel::dump(ostream& s, short detail) const throw()
+   void ObsClockModel::dump(ostream& s, short detail) const noexcept
    {
       s << "min elev:" << elvmask
         << ", max sigma:" << sigmam

--- a/core/lib/ClockModel/ObsClockModel.hpp
+++ b/core/lib/ClockModel/ObsClockModel.hpp
@@ -94,7 +94,7 @@ namespace gpstk
          setSvMode(mode);
       }
 
-      virtual void addEpoch(const ORDEpoch& re) throw(gpstk::InvalidValue) = 0;
+      virtual void addEpoch(const ORDEpoch& re) noexcept(false) = 0;
 
          // set accessor methods ----------------------------------------------   
 
@@ -103,7 +103,7 @@ namespace gpstk
           * @param right #SvModeMap
           * @return a reference to this object
           */
-      ObsClockModel& setSvModeMap(const SvModeMap& right) throw();
+      ObsClockModel& setSvModeMap(const SvModeMap& right) noexcept;
 
          /** 
           * set the SvMode for a particular SV.
@@ -111,7 +111,7 @@ namespace gpstk
           * @param mode #SvMode for the SV
           * @return a reference to this object
           */
-      ObsClockModel& setSvMode(const SatID& svid, const SvMode& mode) throw()
+      ObsClockModel& setSvMode(const SatID& svid, const SvMode& mode) noexcept
       { modes[svid] = mode; return *this; }
       
          /** 
@@ -119,7 +119,7 @@ namespace gpstk
           * @param mode #SvMode for the SVs
           * @return a reference to this object
           */
-      ObsClockModel& setSvMode(const SvMode& mode) throw()
+      ObsClockModel& setSvMode(const SvMode& mode) noexcept
       {
          for(int prn = 1; prn <= gpstk::MAX_PRN; prn++)
          {
@@ -134,7 +134,7 @@ namespace gpstk
           * @param right sigma multiple value
           * @return a reference to this object
           */
-      ObsClockModel& setSigmaMultiplier(double right) throw()
+      ObsClockModel& setSigmaMultiplier(double right) noexcept
       { sigmam = right; return *this; }
    
          /**
@@ -142,13 +142,13 @@ namespace gpstk
           * @param right elevation mask angle value
           * @return a reference to this object
           */
-      ObsClockModel& setElevationMask(double right) throw()
+      ObsClockModel& setElevationMask(double right) noexcept
       { elvmask = right; return *this; }
 
          /** Set useWonkyData true and ords that are flagged as wonky
              will be included in any clock estimation calculations.
          **/
-      ObsClockModel& setUseWonkyData(bool right) throw()
+      ObsClockModel& setUseWonkyData(bool right) noexcept
       { useWonkyData = right; return *this; }
 
          // get accessor methods ----------------------------------------------
@@ -158,7 +158,7 @@ namespace gpstk
           * computation.
           * @return a const reference to the #SvStatusMap
           */
-      const SvStatusMap& getSvStatusMap() const throw()
+      const SvStatusMap& getSvStatusMap() const noexcept
       { return status; };
 
          /**
@@ -167,13 +167,13 @@ namespace gpstk
           * @return #SvStatus
           * @exception ObjectNotFound an ORD for that SV is not in the map
           */
-      SvStatus getSvStatus(const SatID& svid) const throw(ObjectNotFound);
+      SvStatus getSvStatus(const SatID& svid) const noexcept(false);
 
          /**
           * get the map indicating how to use each ORD in the bias computation.
           * @return a const reference to the #SvModeMap
           */
-      const SvModeMap& getSvModeMap() const throw() { return modes; }
+      const SvModeMap& getSvModeMap() const noexcept { return modes; }
 
          /**
           * get how a particular ORD is to be used in the bias computation.
@@ -181,25 +181,25 @@ namespace gpstk
           * @return #SvMode
           * @exception ObjectNotFound a mode for that SV is not in the map
           */
-      SvMode getSvMode(const SatID& svid) const throw(ObjectNotFound);
+      SvMode getSvMode(const SatID& svid) const noexcept(false);
 
          /**
           * returns the sigma multiple value used for ORD stripping.
           * @return sigma multiple
           */
-      double getSigmaMultiplier() const throw() { return sigmam; } 
+      double getSigmaMultiplier() const noexcept { return sigmam; } 
 
          /**
           * returns the elevation mask angle used for ORD stripping.
           * @return elevation mask angle
           */
-      double getElevationMask() const throw() { return elvmask; }
+      double getElevationMask() const noexcept { return elvmask; }
 
 
          /**
           * return the current value of the userWonkyData flag.
           */
-      bool getUseWonkyData() const throw()
+      bool getUseWonkyData() const noexcept
       { return useWonkyData; }
 
          /** Computes an average of all ORD in the epoch that pass the
@@ -208,9 +208,9 @@ namespace gpstk
           * statistics. This is effectivly a simple single epoch clock
           * model. */
       Stats<double> simpleOrdClock(const ORDEpoch& oe)
-         throw(InvalidValue);
+         noexcept(false);
 
-      virtual void dump(std::ostream& s, short detail=1) const throw();
+      virtual void dump(std::ostream& s, short detail=1) const noexcept;
 
       friend std::ostream& operator<<(std::ostream& s, const ObsClockModel& r)
       { r.dump(s, 0); return s; };

--- a/core/lib/ClockModel/ObsEpochMap.cpp
+++ b/core/lib/ClockModel/ObsEpochMap.cpp
@@ -49,7 +49,7 @@ namespace gpstk
    // These are just to facilitate debugging. The format of the data output
    // is quite ad-hoc and may change.
    std::ostream& operator<<(std::ostream& s, const SvObsEpoch& obs)
-      throw()
+      noexcept
    {
       SvObsEpoch::const_iterator i;
       for (i=obs.begin(); i != obs.end(); i++)
@@ -62,7 +62,7 @@ namespace gpstk
    }
 
    std::ostream& operator<<(std::ostream& s, const ObsEpoch& oe)
-      throw()
+      noexcept
    {
       s << oe.time << ", rxClock: " << oe.rxClock << endl;
       ObsEpoch::const_iterator i;

--- a/core/lib/ClockModel/ObsEpochMap.hpp
+++ b/core/lib/ClockModel/ObsEpochMap.hpp
@@ -73,8 +73,8 @@ namespace gpstk
       /// A time history of the observations collected from a single receiver.
    typedef std::map<CommonTime, ObsEpoch> ObsEpochMap;
 
-   std::ostream& operator<<(std::ostream& s, const SvObsEpoch& obs) throw();
-   std::ostream& operator<<(std::ostream& s, const ObsEpoch& oe) throw();
+   std::ostream& operator<<(std::ostream& s, const SvObsEpoch& obs) noexcept;
+   std::ostream& operator<<(std::ostream& s, const ObsEpoch& oe) noexcept;
 
       //@}
 

--- a/core/lib/ClockModel/ObsRngDev.cpp
+++ b/core/lib/ClockModel/ObsRngDev.cpp
@@ -261,7 +261,7 @@ namespace gpstk
    }
 
    std::ostream& operator<<(std::ostream& s, const ObsRngDev& ord)
-      throw()
+      noexcept
    {
       std::ios::fmtflags oldFlags = s.flags();
       s << "t=" << printTime(ord.obstime,"%Y/%03j %02H:%02M:%04.1f")

--- a/core/lib/ClockModel/ObsRngDev.hpp
+++ b/core/lib/ClockModel/ObsRngDev.hpp
@@ -75,7 +75,7 @@ namespace gpstk
           * Creates an empty, useless object to facilitate STL
           * containers of this object.
           */
-      ObsRngDev() throw()
+      ObsRngDev() noexcept
       : obstime(CommonTime::END_OF_TIME), wonky(0) {}
          /**
           * constructor.
@@ -218,65 +218,65 @@ namespace gpstk
                 double gamma = GAMMA_GPS);
    
          /// destructor
-      virtual ~ObsRngDev() throw() {}
+      virtual ~ObsRngDev() noexcept {}
 
          // get accessor methods ----------------------------------------------
          /**
           * returns the time of the SV observation
           * \return time of SV observation
           */
-      const CommonTime& getTime() const throw() { return obstime; }
+      const CommonTime& getTime() const noexcept { return obstime; }
 
          /**
           * returns the observed SV's identifier
           * \return svid
           */
-      SatID getSvID() const throw() { return svid; }
+      SatID getSvID() const noexcept { return svid; }
 
          /**
           * returns the SV azimuth angle (in degrees) in relation to the rx
           * \return SV azimuth angle
           */
-      vfloat getAzimuth() const throw() { return azimuth; }
+      vfloat getAzimuth() const noexcept { return azimuth; }
 
          /**
           * returns elevation (in degrees) of the SV in relation to the rx
           * \return SV elevation angle
           */
-      vfloat getElevation() const throw() { return elevation; }
+      vfloat getElevation() const noexcept { return elevation; }
 
          /**
           * returns the 6-bit SV health bitfield from epehemeris, subframe 1
           * \return SV health bitfield
           */
-      vshort getHealth() const throw() { return health; }
+      vshort getHealth() const noexcept { return health; }
 
          /**
           * returns the Issue Of Data, Clock (IODC) from ephemeris, subframe 1
           * \return ephemeris IODC
           */
-      vshort getIODC() const throw() { return iodc; }
+      vshort getIODC() const noexcept { return iodc; }
 
          /**
           * returns the observed range deviation (ORD) (in meters)
           * \returns ORD
           */
-      double getORD() const throw() { return ord; }
+      double getORD() const noexcept { return ord; }
 
          /**
           * returns the ionospheric offset (in meters)
           * \returns ionospheric offset
           */
-      vdouble getIono() const throw() { return iono; }
+      vdouble getIono() const noexcept { return iono; }
 
          /**
           * returns the tropospheric offset (in meters)
           * \returns tropospheric offset
           */
-      vdouble getTrop() const throw() { return trop; }
+      vdouble getTrop() const noexcept { return trop; }
 
       friend std::ostream& operator<<(std::ostream& s, 
-                                      const ObsRngDev& r) throw();
+                                      const ObsRngDev& r) noexcept;
 
       void applyClockOffset(double clockOffset)
       {ord -= clockOffset;}

--- a/core/lib/CommandLine/CommandLine.cpp
+++ b/core/lib/CommandLine/CommandLine.cpp
@@ -73,7 +73,7 @@ using namespace StringUtils;
 // the main entry point
 int CommandLine::ProcessCommandLine(int argc, char** argv, string PrgmDesc,
                               string& Usage, string& Errors, vector<string>& Unrecog)
-   throw(Exception)
+   noexcept(false)
 {
 try {
    int i,j;
@@ -169,7 +169,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 
 // -----------------------------------------------------------------------------------
 // public
-void CommandLine::DumpConfiguration(ostream& os, string tag) throw(Exception)
+void CommandLine::DumpConfiguration(ostream& os, string tag) noexcept(false)
 {
 try {
    size_t i,j;
@@ -280,7 +280,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 
 // the rest are private
 // -----------------------------------------------------------------------------------
-bool CommandLine::ValidateCommandLine(string& msg) throw(Exception)
+bool CommandLine::ValidateCommandLine(string& msg) noexcept(false)
 {
 try {
    bool isValid(true);
@@ -364,7 +364,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 }
 
 // -----------------------------------------------------------------------------------
-void CommandLine::BuildSyntaxPage(void) throw(Exception)
+void CommandLine::BuildSyntaxPage(void) noexcept(false)
 {
 try {
    size_t i,j,k;
@@ -459,7 +459,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 // -----------------------------------------------------------------------------------
 // re-entrant!
 void CommandLine::PreProcessArgs(const char *in_arg, vector<string>& Args,
-   string& Errors) throw(Exception)
+   string& Errors) noexcept(false)
 {
 try {
    static bool found_cfg_file=false;
@@ -612,7 +612,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 
 // -----------------------------------------------------------------------------------
 void expand_args(vector<string>& oldvalues, vector<string>& newvalues, string& msg)
-   throw(Exception)
+   noexcept(false)
 {
 try {
    string arg;
@@ -650,7 +650,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 // -----------------------------------------------------------------------------------
 // fill values for each option, and Errors and Unrecog
 void CommandLine::Parse(vector<string>& Args, string& Errors, vector<string>& Unrecog)
-   throw(Exception)
+   noexcept(false)
 {
 try {
    size_t i,j;
@@ -737,7 +737,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 }
 
 // -----------------------------------------------------------------------------------
-string CommandLine::SyntaxPage(void) throw(Exception)
+string CommandLine::SyntaxPage(void) noexcept(false)
 {
 try {
    if(syntaxPageBuilt == 2) {
@@ -769,7 +769,7 @@ catch(...) { Exception e("Unknown exception"); GPSTK_THROW(e); }
 
 // -----------------------------------------------------------------------------------
 void CommandLine::Postprocess(string& Errors, vector<string>& Unrecog)
-   throw(Exception)
+   noexcept(false)
 {
 try {
    size_t i,k;

--- a/core/lib/CommandLine/CommandLine.hpp
+++ b/core/lib/CommandLine/CommandLine.hpp
@@ -289,7 +289,7 @@ public:
 
    // -------------------------------------------------------------
    /// Define the text after 'Usage: '; default is '<prgm> [options] ...'
-   void DefineUsageString(std::string str) throw()
+   void DefineUsageString(std::string str) noexcept
    {
       syntaxPage = "Usage: " + str;
       syntaxPageBuilt = 1;
@@ -309,37 +309,37 @@ public:
    ///          1 help was requested
    int ProcessCommandLine(int argc, char** argv, std::string PrgmDesc,
              std::string& Usage, std::string& Errors, std::vector<std::string>& Unrec)
-      throw(gpstk::Exception);
+      noexcept(false);
 
    /// Dump the configuration. Output is of the form
    ///   longOpt Descript : values
    /// if tag is not empty (the default), begin each line with it.
    void DumpConfiguration(std::ostream& os, std::string tag=std::string())
-      throw(gpstk::Exception);
+      noexcept(false);
 
 private:
    /// determine if the command line, as declared, is valid
-   bool ValidateCommandLine(std::string& msg) throw(gpstk::Exception);
+   bool ValidateCommandLine(std::string& msg) noexcept(false);
 
    /// Build the syntax page
-   void BuildSyntaxPage(void) throw(gpstk::Exception);
+   void BuildSyntaxPage(void) noexcept(false);
 
    /// Preprocess the arguments by pulling out debug, etc, replace deprecated options,
    /// drop ignored options, open --file files, open list files (@file) and parse
    /// comma-separated values
    void PreProcessArgs(const char *arg, std::vector<std::string>& Args,
-      std::string& Errors) throw(gpstk::Exception);
+      std::string& Errors) noexcept(false);
 
    /// Parse the (preprocessed) list of args
    void Parse(std::vector<std::string>& Args, std::string& Errors,
-               std::vector<std::string>& Unrecog) throw(gpstk::Exception);
+               std::vector<std::string>& Unrecog) noexcept(false);
 
    /// Generate the usage string (syntax page)
-   std::string SyntaxPage(void) throw(gpstk::Exception);
+   std::string SyntaxPage(void) noexcept(false);
 
    /// Post process - convert value strings to real values
    void Postprocess(std::string& Errors, std::vector<std::string>& Unrecog)
-      throw(gpstk::Exception);
+      noexcept(false);
 
 }; // end class CommandLine
 

--- a/core/lib/CommandLine/CommandOption.hpp
+++ b/core/lib/CommandLine/CommandOption.hpp
@@ -295,7 +295,7 @@ namespace gpstk
          /// Destructor
       virtual ~CommandOptionNoArg() {}
          /// Returns true if this option was found on the command line
-      operator bool() const throw() { return (getCount() != 0); }
+      operator bool() const noexcept { return (getCount() != 0); }
 
    protected:
          /// Default Constructor

--- a/core/lib/FileDirProc/FileFilterFrame.hpp
+++ b/core/lib/FileDirProc/FileFilterFrame.hpp
@@ -76,7 +76,7 @@ namespace gpstk
                       gpstk::CommonTime::BEGINNING_OF_TIME,
                       const gpstk::CommonTime& end = 
                       gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Takes a list of files to open in lieu of day times
       FileFilterFrame(const std::vector<std::string>& fileList,
@@ -84,7 +84,7 @@ namespace gpstk
                       gpstk::CommonTime::BEGINNING_OF_TIME,
                       const gpstk::CommonTime& end = 
                       gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Takes a file name for a single file filter.
          /// This can throw an exception when there's a file error.
@@ -93,7 +93,7 @@ namespace gpstk
                       gpstk::CommonTime::BEGINNING_OF_TIME,
                       const gpstk::CommonTime& end = 
                       gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Uses the FileSpec to retrieve files.  Use filter like you would
          /// in FileHunter, to filter FOR stations, receivers, etc.
@@ -105,7 +105,7 @@ namespace gpstk
                       gpstk::CommonTime::END_OF_TIME,
                       const std::vector<FileHunter::FilterPair>& filter = 
                       std::vector<FileHunter::FilterPair>())
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Gets the files from the file spec and the time, then adds
          /// the data to the filter. Use filter like you would
@@ -118,7 +118,7 @@ namespace gpstk
                 gpstk::CommonTime::END_OF_TIME,
                 const std::vector<FileHunter::FilterPair>& filter = 
                 std::vector<FileHunter::FilterPair>())
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Reads in the file and adds the data to the filter.
       FileFilterFrame& 
@@ -127,7 +127,7 @@ namespace gpstk
                 gpstk::CommonTime::BEGINNING_OF_TIME,
                 const gpstk::CommonTime& end = 
                 gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Takes a list of files to open in lieu of day times
       FileFilterFrame&
@@ -136,7 +136,7 @@ namespace gpstk
                 gpstk::CommonTime::BEGINNING_OF_TIME,
                 const gpstk::CommonTime& end = 
                 gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception);
+         noexcept(false);
 
       virtual ~FileFilterFrame() {}
 
@@ -152,7 +152,7 @@ namespace gpstk
           */
       bool writeFile(const std::string& outputFile,
                      const bool append = false) const
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /**
           * Writes the data to the supplied stream.
@@ -164,13 +164,13 @@ namespace gpstk
           * FileFilterFrameWithHeader for those file types.
           */
       bool writeFile(FileStream& stream) const
-         throw(gpstk::Exception);
+         noexcept(false);
 
    protected:
          ///  Run init() to load the data into the filter.
       void init(const std::vector<FileHunter::FilterPair>& filter= 
                 std::vector<FileHunter::FilterPair>()) 
-         throw(gpstk::Exception);
+         noexcept(false);
 
 
    protected:   
@@ -187,7 +187,7 @@ namespace gpstk
    FileFilterFrame<FileStream,FileData> :: 
    FileFilterFrame(const gpstk::CommonTime& start,
                    const gpstk::CommonTime& end)
-         throw(gpstk::Exception)
+         noexcept(false)
          : startTime(start), endTime(end)
    {}
 
@@ -196,7 +196,7 @@ namespace gpstk
    FileFilterFrame(const std::vector<std::string>& fileList,
                    const gpstk::CommonTime& start,
                    const gpstk::CommonTime& end)
-         throw(gpstk::Exception)
+         noexcept(false)
          : startTime(start), endTime(end)
    {
       typename std::vector<std::string>::const_iterator itr;
@@ -212,7 +212,7 @@ namespace gpstk
    FileFilterFrame(const std::string& filename, 
                    const gpstk::CommonTime& start,
                    const gpstk::CommonTime& end)
-         throw(gpstk::Exception)
+         noexcept(false)
          : fs(filename), startTime(start), endTime(end)
    {
       init();
@@ -224,7 +224,7 @@ namespace gpstk
                    const gpstk::CommonTime& start,
                    const gpstk::CommonTime& end,
                    const std::vector<FileHunter::FilterPair>& filter)
-         throw(gpstk::Exception)
+         noexcept(false)
          : fs(spec), startTime(start), endTime(end)
    {
       init(filter);
@@ -237,7 +237,7 @@ namespace gpstk
              const gpstk::CommonTime& start,
              const gpstk::CommonTime& end,
              const std::vector<FileHunter::FilterPair>& filter)
-      throw(gpstk::Exception)
+      noexcept(false)
    {
       startTime = start;
       endTime = end;
@@ -253,7 +253,7 @@ namespace gpstk
    newSource(const std::string& filename, 
              const gpstk::CommonTime& start,
              const gpstk::CommonTime& end)
-      throw(gpstk::Exception)
+      noexcept(false)
    {
       startTime = start;
       endTime = end;
@@ -269,7 +269,7 @@ namespace gpstk
    newSource(const std::vector<std::string>& fileList, 
              const gpstk::CommonTime& start,
              const gpstk::CommonTime& end)
-      throw(gpstk::Exception)
+      noexcept(false)
    {
       startTime = start;
       endTime = end;
@@ -287,7 +287,7 @@ namespace gpstk
    void
    FileFilterFrame<FileStream,FileData> :: 
    init(const std::vector<FileHunter::FilterPair>& filter)
-      throw(gpstk::Exception)
+      noexcept(false)
    {
          // find the files
       FileHunter fh(fs);
@@ -322,7 +322,7 @@ namespace gpstk
    bool FileFilterFrame<FileStream,FileData> :: 
    writeFile(const std::string& str,
              const bool append) const
-      throw(gpstk::Exception)
+      noexcept(false)
    {
       if (!this->dataVec.empty())
       {
@@ -345,7 +345,7 @@ namespace gpstk
    template <class FileStream, class FileData>
    bool FileFilterFrame<FileStream,FileData> :: 
    writeFile(FileStream& stream)
-      const throw(gpstk::Exception)
+      const noexcept(false)
    {
       if (!this->dataVec.empty())
       {

--- a/core/lib/FileDirProc/FileFilterFrameWithHeader.hpp
+++ b/core/lib/FileDirProc/FileFilterFrameWithHeader.hpp
@@ -78,7 +78,7 @@ namespace gpstk
                                 gpstk::CommonTime::BEGINNING_OF_TIME,
                                 const gpstk::CommonTime& end = 
                                 gpstk::CommonTime::END_OF_TIME)
-            throw(gpstk::Exception) :
+            noexcept(false) :
             FileFilterFrame<FileStream, FileData>(start, end)
       {}
 
@@ -88,7 +88,7 @@ namespace gpstk
                                 gpstk::CommonTime::BEGINNING_OF_TIME,
                                 const gpstk::CommonTime& end = 
                                 gpstk::CommonTime::END_OF_TIME)
-            throw(gpstk::Exception) :
+            noexcept(false) :
             FileFilterFrame<FileStream, FileData>(fileList, start, end)
       {
          std::vector<std::string>::const_iterator itr = fileList.begin();
@@ -107,7 +107,7 @@ namespace gpstk
                                 gpstk::CommonTime::BEGINNING_OF_TIME,
                                 const gpstk::CommonTime& end = 
                                 gpstk::CommonTime::END_OF_TIME)
-            throw(gpstk::Exception) :
+            noexcept(false) :
             FileFilterFrame<FileStream, FileData>(filename, start, end)
       {init();}
 
@@ -121,7 +121,7 @@ namespace gpstk
                                 gpstk::CommonTime::END_OF_TIME,
                                 const std::vector<FileHunter::FilterPair>& filter = 
                                 std::vector<FileHunter::FilterPair>())
-            throw(gpstk::Exception) :
+            noexcept(false) :
             FileFilterFrame<FileStream, FileData>(spec, start, end, filter)
       {init(filter);}
 
@@ -136,7 +136,7 @@ namespace gpstk
                 gpstk::CommonTime::END_OF_TIME,
                 const std::vector<FileHunter::FilterPair>& filter = 
                 std::vector<FileHunter::FilterPair>())
-         throw(gpstk::Exception)
+         noexcept(false)
       {
          FileFilterFrame<FileStream, FileData>::newSource(filespec, start,
                                                           end, filter);
@@ -151,7 +151,7 @@ namespace gpstk
                 gpstk::CommonTime::BEGINNING_OF_TIME,
                 const gpstk::CommonTime& end = 
                 gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception)
+         noexcept(false)
       {
          FileFilterFrame<FileStream, FileData>::newSource(filename, start,
                                                           end);
@@ -166,7 +166,7 @@ namespace gpstk
                 gpstk::CommonTime::BEGINNING_OF_TIME,
                 const gpstk::CommonTime& end = 
                 gpstk::CommonTime::END_OF_TIME)
-         throw(gpstk::Exception)
+         noexcept(false)
       {
          FileFilterFrame<FileStream, FileData>::newSource(fileList, start,
                                                           end);
@@ -190,7 +190,7 @@ namespace gpstk
           */
       bool writeFile(const std::string& outputFile,
                      const FileHeader& fh) const
-         throw(gpstk::Exception);
+         noexcept(false);
 
       /// Returns a list of the data in *this that isn't in r.
       template <class BinaryPredicate>
@@ -255,16 +255,16 @@ namespace gpstk
       { return headerList.size(); }
 
       typename std::list<FileHeader>::const_iterator beginHeader() const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       typename std::list<FileHeader>::const_iterator endHeader() const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       typename std::list<FileHeader>::iterator beginHeader() 
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       typename std::list<FileHeader>::iterator endHeader() 
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       bool emptyHeader() const
       { return headerList.empty(); }
@@ -273,26 +273,26 @@ namespace gpstk
       { return headerList.size(); }
 
       FileHeader& frontHeader()
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       const FileHeader& frontHeader() const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       FileHeader& backHeader()
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
       const FileHeader& backHeader() const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
    protected:
          ///  Run init() to load the data into the filter.  
       void init(const std::vector<FileHunter::FilterPair>& filter= 
                 std::vector<FileHunter::FilterPair>()) 
-         throw(gpstk::Exception);
+         noexcept(false);
 
          /// Check to make sure headerList is empty
          /// @throw InvalidRequest if headerList is empty
-      inline void chl(const std::string& req) throw(gpstk::InvalidRequest)
+      inline void chl(const std::string& req) noexcept(false)
       {
          gpstk::InvalidRequest exc("Header list is empty attempting to"
                                    " satisfy "+req+" request.");
@@ -312,7 +312,7 @@ namespace gpstk
    bool FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::
    writeFile(const std::string& outputFile,
              const FileHeader& fh) const
-      throw(gpstk::Exception)
+      noexcept(false)
    {
          // make the directory (if needed)
       std::string::size_type pos = outputFile.rfind('/');
@@ -334,7 +334,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    typename std::list<FileHeader>::const_iterator
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::beginHeader()
-      const throw(gpstk::InvalidRequest)
+      const noexcept(false)
    {
       try { chl("beginHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -345,7 +345,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    typename std::list<FileHeader>::const_iterator
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::endHeader()
-      const throw(gpstk::InvalidRequest)
+      const noexcept(false)
    {
       try { chl("endHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -356,7 +356,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    typename std::list<FileHeader>::iterator
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::beginHeader()
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       try { chl("beginHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -368,7 +368,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    typename std::list<FileHeader>::iterator
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::endHeader()
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       try { chl("endHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -379,7 +379,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    FileHeader&
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::frontHeader()
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       try { chl("frontHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -391,7 +391,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    const FileHeader&
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::frontHeader()
-      const throw(gpstk::InvalidRequest)
+      const noexcept(false)
    {
       try { chl("frontHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -403,7 +403,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    FileHeader&
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::backHeader()
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       try { chl("backHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -415,7 +415,7 @@ namespace gpstk
    template <class FileStream, class FileData, class FileHeader>
    const FileHeader&
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader>::backHeader()
-      const throw(gpstk::InvalidRequest)
+      const noexcept(false)
    {
       try { chl("backHeader"); }
       catch(gpstk::InvalidRequest exc)
@@ -427,7 +427,7 @@ namespace gpstk
    void
    FileFilterFrameWithHeader<FileStream,FileData,FileHeader> :: 
    init(const std::vector<FileHunter::FilterPair>& filter)
-      throw(gpstk::Exception)
+      noexcept(false)
    {
          // find the files
       FileHunter fh(this->fs);

--- a/core/lib/FileDirProc/FileSpec.cpp
+++ b/core/lib/FileDirProc/FileSpec.cpp
@@ -102,7 +102,7 @@ namespace gpstk
    }
    
    string FileSpec::convertFileSpecType(const FileSpecType fst)
-      throw(FileSpecException)
+      noexcept(false)
    {
       if (fst == station)          return string("n");
       else if (fst == receiver)    return string("r");
@@ -141,7 +141,7 @@ namespace gpstk
    }
 
    FileSpec::FileSpecType FileSpec::convertFileSpecType(const string& fst)
-      throw(FileSpecException)
+      noexcept(false)
    {
       if (fst == string("n"))        return station;
       else if (fst == string("r"))   return receiver;
@@ -182,7 +182,7 @@ namespace gpstk
 
 
    string FileSpec::createSearchString() const
-      throw(FileSpecException)
+      noexcept(false)
    {
       string searchString;
 
@@ -216,7 +216,7 @@ namespace gpstk
 
    string FileSpec::extractField(const string& filename, 
                                  const FileSpecType fst) const
-      throw(FileSpecException)
+      noexcept(false)
    {
          // stupidity check - is it a valid FST?
       if ((fst <= unknown) || (fst >= end))
@@ -246,7 +246,7 @@ namespace gpstk
    }
 
    bool FileSpec::hasField(const FileSpecType fst) const
-      throw(FileSpecException)
+      noexcept(false)
    {
       vector<FileSpecElement>::const_iterator itr = fileSpecList.begin();
       while (itr != fileSpecList.end())
@@ -267,7 +267,7 @@ namespace gpstk
 
 
    CommonTime FileSpec::extractCommonTime(const string& filename) const
-      throw(FileSpecException)
+      noexcept(false)
    {
          // this uses CommonTime::setToString to get the time out
       try
@@ -342,7 +342,7 @@ namespace gpstk
 
    void FileSpec::sortList(vector<string>& fileList, 
                            const FileSpecSortType fsst) const
-      throw(FileSpecException)
+      noexcept(false)
    {
       FileSpecSort q(*this, fsst);
       stable_sort(fileList.begin(), fileList.end(), q);
@@ -426,7 +426,7 @@ namespace gpstk
    }
 
    void FileSpec::init(const string& fileSpec)
-      throw(FileSpecException)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/FileDirProc/FileSpec.hpp
+++ b/core/lib/FileDirProc/FileSpec.hpp
@@ -144,7 +144,7 @@ namespace gpstk
 
          /// Constructor with a string to parse
       FileSpec(const std::string& fileSpec)
-         throw(FileSpecException)
+         noexcept(false)
       {init(fileSpec);}
 
          /// Destructor
@@ -152,7 +152,7 @@ namespace gpstk
 
          /// Reinitializes this FileSpec with the new string
       virtual FileSpec& newSpec(const std::string& fileSpec)
-         throw(FileSpecException)
+         noexcept(false)
       {init(fileSpec); return *this;}
 
          /// Returns the string of the filespec
@@ -166,7 +166,7 @@ namespace gpstk
           * @throw FileSpecException when there's an error in the FileSpec
           */
       virtual std::string createSearchString() const
-         throw(FileSpecException);
+         noexcept(false);
 
          /**
           * Given a file name and a field, returns that field from the string.
@@ -178,14 +178,14 @@ namespace gpstk
           */
       virtual std::string extractField(const std::string& filename, 
                                        const FileSpecType) const
-         throw(FileSpecException);
+         noexcept(false);
 
          /**
           * Given a field type, returns true if the FileSpec has that field.
           * @throw FileSpecException when you pass in an invalid FileSpecType
           */
       virtual bool hasField(const FileSpecType) const
-         throw(FileSpecException);
+         noexcept(false);
 
          /** 
           * If possible, returns a CommonTime object with the time the file
@@ -195,7 +195,7 @@ namespace gpstk
           */
       virtual gpstk::CommonTime extractCommonTime(const std::string& filename)
          const
-         throw(FileSpecException);
+         noexcept(false);
 
          /**
           * For the given FileSpec, fills in the fields with the given
@@ -225,7 +225,7 @@ namespace gpstk
           */
       virtual void sortList(std::vector<std::string>& fileList, 
                             const FileSpecSortType fsst = ascending) const
-         throw(FileSpecException);
+         noexcept(false);
 
          /// semi-nicely print the FileSpec to the stream.
       virtual void dump(std::ostream& o) const;
@@ -233,7 +233,7 @@ namespace gpstk
    protected:
          /// Parses the string into the FileSpec object
       virtual void init(const std::string& fileSpec)
-         throw(FileSpecException);
+         noexcept(false);
 
    public:
          /**
@@ -242,7 +242,7 @@ namespace gpstk
           *  any known types
           */
       static std::string convertFileSpecType(const FileSpecType)
-      throw(FileSpecException);
+      noexcept(false);
 
          /**
           * Converts the string into its corresponding FileSpecType
@@ -250,7 +250,7 @@ namespace gpstk
           *  any known types
           */
       static FileSpecType convertFileSpecType(const std::string&)
-         throw(FileSpecException);
+         noexcept(false);
 
    protected:
          /// This is an internal, private class of FileSpec that holds

--- a/core/lib/FileDirProc/FileStore.hpp
+++ b/core/lib/FileDirProc/FileStore.hpp
@@ -67,7 +67,7 @@ namespace gpstk
    public:
 
          /// Constructor.
-      FileStore() throw() {};
+      FileStore() noexcept {};
 
          /// destructor
       ~FileStore() {};
@@ -84,7 +84,7 @@ namespace gpstk
       
          /// Add a filename, with its header, to the store
       void addFile(const std::string& fn, HeaderType& header)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          if(headerMap.find(fn) != headerMap.end()) {
             dump(std::cout, 1);
@@ -96,7 +96,7 @@ namespace gpstk
 
          /// Access the header for a given filename
       const HeaderType& getHeader(const std::string& fn) const
-         throw(InvalidRequest)
+         noexcept(false)
       {
          typename std::map<std::string, HeaderType>::const_iterator iter_fn = headerMap.find(fn);
          if( iter_fn == headerMap.end())
@@ -112,7 +112,7 @@ namespace gpstk
 
          /// dump a list of file names
       void dump(std::ostream& os = std::cout, short detail = 0)
-         const throw()
+         const noexcept
       {
          int n(0);
          os << "Dump of FileStore\n";
@@ -130,16 +130,16 @@ namespace gpstk
 
          /// Clear the contents of the (filename, header) map 
       void clear()
-         throw()
+         noexcept
       {
          headerMap.clear();
       }
 
 
          /// Return the size of the (filename,header) map
-      unsigned size() const throw() { return headerMap.size(); }
+      unsigned size() const noexcept { return headerMap.size(); }
 
-      unsigned nfiles() const throw() { return size(); }
+      unsigned nfiles() const noexcept { return size(); }
 
    }; // end class FileStore
 

--- a/core/lib/FileDirProc/RTFileFrame.hpp
+++ b/core/lib/FileDirProc/RTFileFrame.hpp
@@ -241,7 +241,7 @@ namespace gpstk
                   const gpstk::CommonTime& ending = gpstk::CommonTime::END_OF_TIME, 
                   const FileReadingMode frm = AppendedData,
                   const GetRecordMode grm = Dumb)
-         throw(gpstk::Exception);
+         noexcept(false);
       
          /// destructor
       ~RTFileFrame();
@@ -349,7 +349,7 @@ namespace gpstk
                                      const gpstk::CommonTime& ending, 
                                      const RTFileFrameHelper::FileReadingMode frm,
                                      const RTFileFrameHelper::GetRecordMode grm)
-   throw(gpstk::Exception)
+   noexcept(false)
       : fileStream(NULL), fs(fnFormat), startTime(beginning), 
       currentTime(beginning), endTime(ending), readMode(frm), getMode(grm)
    {

--- a/core/lib/FileHandling/Binex/BinexData.cpp
+++ b/core/lib/FileHandling/Binex/BinexData.cpp
@@ -80,7 +80,7 @@ namespace gpstk
 
    // -------------------------------------------------------------------------
    BinexData::UBNXI::UBNXI(unsigned long ul)
-      throw(FFStreamError)
+      noexcept(false)
    {
       if (ul < 128)
       {
@@ -119,7 +119,7 @@ namespace gpstk
       const std::string&  inBuffer,
       size_t              offset,
       bool                littleEndian)
-         throw(FFStreamError)
+         noexcept(false)
    {
       if (offset > inBuffer.size() )
       {
@@ -271,7 +271,7 @@ namespace gpstk
       size_t        offset,
       bool          reverseBytes,
       bool          littleEndian)
-         throw(FFStreamError)
+         noexcept(false)
    {
       unsigned char mask = 0;
       char          buffer [MAX_BYTES];
@@ -335,7 +335,7 @@ namespace gpstk
       size_t         offset,
       bool           reverseBytes,
       bool           littleEndian) const
-         throw(FFStreamError)
+         noexcept(false)
    {
       std::string  buffer;
       encode(buffer, 0, littleEndian);
@@ -381,7 +381,7 @@ namespace gpstk
 
    // -------------------------------------------------------------------------
    BinexData::MGFZI::MGFZI(long long ll)
-      throw(FFStreamError)
+      noexcept(false)
    {
       value = ll;
       long long absValue = llabs(ll);
@@ -437,7 +437,7 @@ namespace gpstk
       const std::string&  inBuffer,
       size_t              offset,
       bool                littleEndian)
-         throw(FFStreamError)
+         noexcept(false)
    {
       long long          absValue = 0;
       unsigned char      flags;
@@ -813,7 +813,7 @@ namespace gpstk
       size_t        offset,
       bool          reverseBytes,
       bool          littleEndian)
-         throw(FFStreamError)
+         noexcept(false)
    {
       unsigned char  buffer   [MAX_BYTES];
       unsigned char  flags;
@@ -874,7 +874,7 @@ namespace gpstk
       size_t        offset,
       bool          reverseBytes,
       bool          littleEndian) const
-         throw(FFStreamError)
+         noexcept(false)
    {
       std::string  buffer;
       encode(buffer, 0, littleEndian);
@@ -930,7 +930,7 @@ namespace gpstk
    // -------------------------------------------------------------------------
    BinexData::BinexData(RecordID recordID,
                         SyncByte recordFlags)
-      throw()
+      noexcept
    {
       setRecordFlags(recordFlags);
       setRecordID(recordID);
@@ -959,7 +959,7 @@ namespace gpstk
    // -------------------------------------------------------------------------
    BinexData&
    BinexData::setRecordID(RecordID id)
-      throw(FFStreamError)
+      noexcept(false)
    {
       if (id > UBNXI::MAX_VALUE)
       {
@@ -1023,7 +1023,7 @@ namespace gpstk
    // -------------------------------------------------------------------------
    BinexData&
    BinexData::ensureMessageCapacity(size_t cap)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       if (cap > UBNXI::MAX_VALUE)
       {
@@ -1056,7 +1056,7 @@ namespace gpstk
    BinexData::updateMessageData(
       size_t&      offset,
       const UBNXI& data)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
    {
       bool   littleEndian  = ( (syncByte & eBigEndian) == 0) ? true : false;
       ensureMessageCapacity(offset + data.getSize() );
@@ -1070,7 +1070,7 @@ namespace gpstk
    BinexData::updateMessageData(
       size_t&      offset,
       const MGFZI& data)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
    {
       bool   littleEndian  = ( (syncByte & eBigEndian) == 0) ? true : false;
       ensureMessageCapacity(offset + data.getSize() );
@@ -1085,7 +1085,7 @@ namespace gpstk
       size_t&            offset,
       const std::string& data,
       size_t             size)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
    {
       ensureMessageCapacity(offset + size);
       if (size > data.size() )
@@ -1107,7 +1107,7 @@ namespace gpstk
       size_t&     offset,
       const char  *data,
       size_t      size)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
    {
       ensureMessageCapacity(offset + size);
       msg.replace(offset, size, data, size);
@@ -1120,7 +1120,7 @@ namespace gpstk
    BinexData::extractMessageData(
       size_t& offset,
       UBNXI&  data)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
    {
       if (offset > msg.size() )
       {
@@ -1139,7 +1139,7 @@ namespace gpstk
    BinexData::extractMessageData(
       size_t& offset,
       MGFZI&  data)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
    {
       if (offset > msg.size() )
       {
@@ -1159,7 +1159,7 @@ namespace gpstk
       size_t&      offset,
       std::string& data,
       size_t       size) const
-         throw(InvalidParameter)
+         noexcept(false)
    {
       if (offset + size > msg.size() )
       {
@@ -1176,8 +1176,7 @@ namespace gpstk
    // -------------------------------------------------------------------------
    void
    BinexData::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError,
-            StringUtils::StringException)
+      noexcept(false)
    {
       if (NULL == dynamic_cast<BinexStream*>(&ffs))
       {
@@ -1191,8 +1190,7 @@ namespace gpstk
    // -------------------------------------------------------------------------
    void
    BinexData::putRecord(std::ostream& strm) const
-      throw(std::exception, FFStreamError,
-            StringUtils::StringException)
+      noexcept(false)
    {
       try
       {
@@ -1269,7 +1267,7 @@ namespace gpstk
 
    // -------------------------------------------------------------------------
    void BinexData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, StringUtils::StringException)
+      noexcept(false)
    {
       if (NULL == dynamic_cast<BinexStream*>(&ffs))
       {
@@ -1282,7 +1280,7 @@ namespace gpstk
 
    // -------------------------------------------------------------------------
    size_t BinexData::getRecord(std::istream& strm)
-      throw(std::exception, FFStreamError, StringUtils::StringException)
+      noexcept(false)
    {
       size_t        offset            = 0;
 
@@ -1658,7 +1656,7 @@ namespace gpstk
    BinexData::parseBuffer(const std::string&  buffer,
                           size_t              offset,
                           size_t              size)
-      throw(FFStreamError)
+      noexcept(false)
    {
       unsigned long long value = 0;
       if (size > sizeof(value) )

--- a/core/lib/FileHandling/Binex/BinexData.hpp
+++ b/core/lib/FileHandling/Binex/BinexData.hpp
@@ -116,7 +116,7 @@ namespace gpstk
              * Constructor with unsigned long initialization value.
              */
          UBNXI(unsigned long ul)
-            throw(FFStreamError);
+            noexcept(false);
 
             /**
              * Copies another UBNXI.
@@ -215,7 +215,7 @@ namespace gpstk
          decode(const std::string& inBuffer,
                 size_t             offset       = 0,
                 bool               littleEndian = false)
-            throw(FFStreamError);
+            noexcept(false);
 
             /**
              * Converts the UBNXI to a series of bytes placed in outBuffer.
@@ -252,7 +252,7 @@ namespace gpstk
               size_t        offset       = 0,
               bool          reverseBytes = false,
               bool          littleEndian = false)
-            throw(FFStreamError);
+            noexcept(false);
 
             /**
              * Attempts to write the UBNXI to the specified output stream.
@@ -273,7 +273,7 @@ namespace gpstk
                size_t        offset       = 0,
                bool          reverseBytes = false,
                bool          littleEndian = false) const
-            throw(FFStreamError);
+            noexcept(false);
 
       protected:
 
@@ -313,7 +313,7 @@ namespace gpstk
              * Constructor with a long long initialization value.
              */
          MGFZI(long long ll)
-            throw(FFStreamError);
+            noexcept(false);
 
             /**
              * Copies another MGFZI.
@@ -412,7 +412,7 @@ namespace gpstk
          decode(const std::string& inBuffer,
                 size_t             offset       = 0,
                 bool               littleEndian = false)
-            throw(FFStreamError);
+            noexcept(false);
 
             /**
              * Converts the MGFZI to a series of bytes placed in outBuffer.
@@ -446,7 +446,7 @@ namespace gpstk
               size_t      offset       = 0,
               bool        reverseBytes = false,
               bool        littleEndian = false)
-            throw(FFStreamError);
+            noexcept(false);
 
             /**
              * Attempts to write the MGFZI to the specified output stream.
@@ -465,7 +465,7 @@ namespace gpstk
                size_t      offset       = 0,
                bool        reverseBytes = false,
                bool        littleEndian = false) const
-            throw(FFStreamError);
+            noexcept(false);
 
       protected:
 
@@ -488,7 +488,7 @@ namespace gpstk
           */
       BinexData(RecordID recordID,
                 SyncByte recordFlags = DEFAULT_RECORD_FLAGS)
-         throw();
+         noexcept;
 
          /**
           * Copies another BinexData object.
@@ -566,7 +566,7 @@ namespace gpstk
           */
       BinexData&
       setRecordID(RecordID id)
-         throw(FFStreamError);
+         noexcept(false);
 
          /**
           * Returns the number of bytes required to represent the entire record
@@ -590,7 +590,7 @@ namespace gpstk
           */
       BinexData&
       ensureMessageCapacity(size_t cap)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /**
           * Returns the current length of the record head, i.e. the combined
@@ -655,7 +655,7 @@ namespace gpstk
       updateMessageData(
          size_t&      offset,
          const UBNXI& data)
-         throw(FFStreamError, InvalidParameter);
+         noexcept(false);
 
          /**
           * Updates the message buffer with the specified MGFZI.  The location
@@ -672,7 +672,7 @@ namespace gpstk
       updateMessageData(
          size_t&      offset,
          const MGFZI& data)
-         throw(FFStreamError, InvalidParameter);
+         noexcept(false);
 
          /**
           * Updates the message buffer with the specified raw data.  The
@@ -691,7 +691,7 @@ namespace gpstk
          size_t&            offset,
          const std::string& data,
          size_t             size)
-         throw(FFStreamError, InvalidParameter);
+         noexcept(false);
 
          /**
           * Updates the message buffer with the specified raw data.  The
@@ -710,7 +710,7 @@ namespace gpstk
          size_t&     offset,
          const char  *data,
          size_t      size)
-         throw(FFStreamError, InvalidParameter);
+         noexcept(false);
 
          /**
           * Updates the message buffer with the specified data.  The location
@@ -732,7 +732,7 @@ namespace gpstk
          size_t&      offset,
          const T&     data,
          size_t       size)
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
       {
          if (size > sizeof(T) )
          {
@@ -768,7 +768,7 @@ namespace gpstk
       extractMessageData(
          size_t& offset,
          UBNXI&  data)
-         throw(FFStreamError, InvalidParameter);
+         noexcept(false);
 
          /**
           * Extracts a MGFZI from the message buffer.  The location within the
@@ -784,7 +784,7 @@ namespace gpstk
       extractMessageData(
          size_t& offset,
          MGFZI&  data)
-         throw(FFStreamError, InvalidParameter);
+         noexcept(false);
 
          /**
           * Extracts raw data from the message buffer.  The location within the
@@ -804,7 +804,7 @@ namespace gpstk
          size_t&      offset,
          std::string& data,
          size_t       size) const
-         throw(InvalidParameter);
+         noexcept(false);
 
          /**
           * Extracts data from the message buffer.  The location within the
@@ -826,7 +826,7 @@ namespace gpstk
          size_t&      offset,
          T&           data,
          size_t       size) const
-         throw(FFStreamError, InvalidParameter)
+         noexcept(false)
       {
          if (size > sizeof(T) )
          {
@@ -857,8 +857,7 @@ namespace gpstk
           */
       virtual void
       putRecord(std::ostream& s) const
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
          /**
           * Retrieves a BINEX record from the specified generic input stream.
@@ -866,8 +865,7 @@ namespace gpstk
           */
       virtual size_t
       getRecord(std::istream& s)
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
    protected:
 
@@ -876,8 +874,7 @@ namespace gpstk
           */
       virtual void
       reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function retrieves a BINEX record from the given FFStream.
@@ -890,8 +887,7 @@ namespace gpstk
           */
       virtual void
       reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
          /**
           * @param bufs    A NULL-terminated list of pointers to byte buffers
@@ -937,7 +933,7 @@ namespace gpstk
       parseBuffer(const std::string&  buffer,
                   size_t              offset,
                   size_t              size)
-         throw(FFStreamError);
+         noexcept(false);
 
          /**
           * Reverses the order of the first bufferLength bytes in the

--- a/core/lib/FileHandling/Binex/BinexStream.hpp
+++ b/core/lib/FileHandling/Binex/BinexStream.hpp
@@ -80,7 +80,7 @@ namespace gpstk
           * data.  BINEX can be either big-endian or little-endian so
           * this isn't really useful.  As such, DO NOT USE writeData
           * or getData in the implementation of BinexData. */
-      virtual bool isStreamLittleEndian() const throw()
+      virtual bool isStreamLittleEndian() const noexcept
       { return true; }
    };
 

--- a/core/lib/FileHandling/FFBinaryStream.cpp
+++ b/core/lib/FileHandling/FFBinaryStream.cpp
@@ -73,7 +73,7 @@ namespace gpstk
 
 
    void FFBinaryStream ::
-   getData(char* buff, size_t length) throw(EndOfFile, FFStreamError)
+   getData(char* buff, size_t length) noexcept(false)
    {
       try
       {
@@ -103,7 +103,7 @@ namespace gpstk
 
    void FFBinaryStream ::
    writeData(const char* buff, size_t length)
-      throw(FFStreamError)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/FileHandling/FFBinaryStream.hpp
+++ b/core/lib/FileHandling/FFBinaryStream.hpp
@@ -81,23 +81,23 @@ namespace gpstk
           *   from this stream doesn't match the size of a T-object.
           * @return the decoded data
           */
-      inline void getData(uint8_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(uint16_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(uint32_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(uint64_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(int8_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(int16_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(int32_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(int64_t& v) throw(EndOfFile, FFStreamError);
-      inline void getData(float& v) throw(EndOfFile, FFStreamError);
-      inline void getData(double& v) throw(EndOfFile, FFStreamError);
+      inline void getData(uint8_t& v) noexcept(false);
+      inline void getData(uint16_t& v) noexcept(false);
+      inline void getData(uint32_t& v) noexcept(false);
+      inline void getData(uint64_t& v) noexcept(false);
+      inline void getData(int8_t& v) noexcept(false);
+      inline void getData(int16_t& v) noexcept(false);
+      inline void getData(int32_t& v) noexcept(false);
+      inline void getData(int64_t& v) noexcept(false);
+      inline void getData(float& v) noexcept(false);
+      inline void getData(double& v) noexcept(false);
 
          /** Read raw data into a buffer.
           * @param[out] buff the buffer to store the stream data
           *   into. Must be pre-allocated to at least length bytes.
           * @param[in] length the number of bytes to read from the stream. */
       void getData(char* buff, size_t length)
-         throw(EndOfFile, FFStreamError);
+         noexcept(false);
 
          /**
           * Writes a T-object directly from the stream in binary form.
@@ -106,25 +106,25 @@ namespace gpstk
           *   to this stream doesn't match the size of a T-object.
           * @return a T-object
           */
-      inline void writeData(uint8_t v) throw(FFStreamError);
-      inline void writeData(uint16_t v) throw(FFStreamError);
-      inline void writeData(uint32_t v) throw(FFStreamError);
-      inline void writeData(uint64_t v) throw(FFStreamError);
-      inline void writeData(int8_t v) throw(FFStreamError);
-      inline void writeData(int16_t v) throw(FFStreamError);
-      inline void writeData(int32_t v) throw(FFStreamError);
-      inline void writeData(int64_t v) throw(FFStreamError);
-      inline void writeData(float v) throw(FFStreamError);
-      inline void writeData(double v) throw(FFStreamError);
+      inline void writeData(uint8_t v) noexcept(false);
+      inline void writeData(uint16_t v) noexcept(false);
+      inline void writeData(uint32_t v) noexcept(false);
+      inline void writeData(uint64_t v) noexcept(false);
+      inline void writeData(int8_t v) noexcept(false);
+      inline void writeData(int16_t v) noexcept(false);
+      inline void writeData(int32_t v) noexcept(false);
+      inline void writeData(int64_t v) noexcept(false);
+      inline void writeData(float v) noexcept(false);
+      inline void writeData(double v) noexcept(false);
 
       void writeData(const char* buff, size_t length)
-         throw(FFStreamError);
+         noexcept(false);
 
          /** Child classes must defined this method to determine how
           * decodeData and encodeData behave with respect to byte
           * ordering. This defines the byte ordering of the file
           * format. */
-      virtual bool isStreamLittleEndian() const throw() = 0;
+      virtual bool isStreamLittleEndian() const noexcept = 0;
 
    };
       //@}
@@ -151,126 +151,126 @@ namespace gpstk
 
 
    inline void FFBinaryStream :: getData(uint8_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       char *buf = reinterpret_cast<char*>(&v);
       getData(buf, sizeof(v));
    }
 
    inline void FFBinaryStream :: getData(uint16_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohs,buntohs);
    }
 
    inline void FFBinaryStream :: getData(uint32_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohl,buntohl);
    }
 
    inline void FFBinaryStream :: getData(uint64_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohll,buntohll);
    }
 
    inline void FFBinaryStream :: getData(int8_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       char *buf = reinterpret_cast<char*>(&v);
       getData(buf, sizeof(v));
    }
 
    inline void FFBinaryStream :: getData(int16_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohss,buntohss);
    }
 
    inline void FFBinaryStream :: getData(int32_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohsl,buntohsl);
    }
 
    inline void FFBinaryStream :: getData(int64_t& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohsll,buntohsll);
    }
 
    inline void FFBinaryStream :: getData(float& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohf,buntohf);
    }
 
    inline void FFBinaryStream :: getData(double& v)
-      throw(EndOfFile, FFStreamError)
+      noexcept(false)
    {
       FFBIN_GET_DATA(buitohd,buntohd);
    }
 
 
    inline void FFBinaryStream :: writeData(uint8_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       char *buf = reinterpret_cast<char*>(&v);
       writeData(buf, sizeof(v));
    }
 
    inline void FFBinaryStream :: writeData(uint16_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtois,buhtons);
    }
 
    inline void FFBinaryStream :: writeData(uint32_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoil,buhtonl);
    }
 
    inline void FFBinaryStream :: writeData(uint64_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoill,buhtonll);
    }
 
    inline void FFBinaryStream :: writeData(int8_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       char *buf = reinterpret_cast<char*>(&v);
       writeData(buf, sizeof(v));
    }
 
    inline void FFBinaryStream :: writeData(int16_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoiss,buhtonss);
    }
 
    inline void FFBinaryStream :: writeData(int32_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoisl,buhtonsl);
    }
 
    inline void FFBinaryStream :: writeData(int64_t v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoisll,buhtonsll);
    }
 
    inline void FFBinaryStream :: writeData(float v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoif,buhtonf);
    }
 
    inline void FFBinaryStream :: writeData(double v)
-      throw(FFStreamError)
+      noexcept(false)
    {
       FFBIN_WRITE_DATA(buhtoid,buhtond);
    }

--- a/core/lib/FileHandling/FFData.cpp
+++ b/core/lib/FileHandling/FFData.cpp
@@ -45,26 +45,26 @@
 namespace gpstk
 {
    void FFData::putRecord(FFStream& s) const 
-      throw(FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    { 
       s.tryFFStreamPut(*this); 
    }
    
    void FFData::getRecord(FFStream& s)
-      throw(FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    { 
       s.tryFFStreamGet(*this); 
    }
    
    std::ostream& operator<<(FFStream& o, const FFData& f)
-         throw(FFStreamError, gpstk::StringUtils::StringException)
+         noexcept(false)
    {
       f.putRecord(o);
       return o;
    }
 
    std::istream& operator>>(FFStream& i, FFData& f)
-         throw(FFStreamError, gpstk::StringUtils::StringException)
+         noexcept(false)
    {
       f.getRecord(i);
       return i;

--- a/core/lib/FileHandling/FFData.hpp
+++ b/core/lib/FileHandling/FFData.hpp
@@ -93,7 +93,7 @@ namespace gpstk
           * @param s a FFStream-based stream
           */
       void putRecord(FFStream& s) const 
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * Retrieve a "record" from the given stream.
@@ -109,7 +109,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       void getRecord(FFStream& s) 
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * Send debug output to the given stream.
@@ -137,7 +137,7 @@ namespace gpstk
           * @return a reference to \c o
           */
       friend std::ostream& operator<<(FFStream& o, const FFData& f)
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * Generic formatted input operator.
@@ -157,20 +157,18 @@ namespace gpstk
           * class.
           */
       friend std::istream& operator>>(FFStream& i, FFData& f)
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
       friend class FFStream;
 
    protected:
          /// Does the actual reading from the stream into this FFData object.
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, gpstk::StringUtils::StringException, 
-               gpstk::FFStreamError) = 0;
+         noexcept(false) = 0;
 
          /// Does the actual writing from the stream into this FFData object.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, gpstk::StringUtils::StringException, 
-               gpstk::FFStreamError) = 0;
+         noexcept(false) = 0;
    }; // class
 
       //@}

--- a/core/lib/FileHandling/FFStream.cpp
+++ b/core/lib/FileHandling/FFStream.cpp
@@ -158,7 +158,7 @@ namespace gpstk
 
 
    void FFStream::tryFFStreamGet(FFData& rec)
-      throw(FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
          // JMK 2015/12/07 - some implementations of streams will
          // raise exceptions in tellg if eofbit is set but not
@@ -281,7 +281,7 @@ namespace gpstk
       // etc) to be retained.
    void FFStream ::
    tryFFStreamPut(const FFData& rec)
-      throw(FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
          // Mark where we start in case there is an error.
       long initialPosition = tellg();

--- a/core/lib/FileHandling/FFStream.hpp
+++ b/core/lib/FileHandling/FFStream.hpp
@@ -165,7 +165,7 @@ namespace gpstk
           * @endcode
           * where \a ffstreamobject is the name of your stream object.
           */
-      inline void conditionalThrow(void) throw(FFStreamError);
+      inline void conditionalThrow(void) noexcept(false);
 
          /// Check if the input stream is the kind of RinexObsStream
       static bool isFFStream(std::istream& i);
@@ -189,13 +189,13 @@ namespace gpstk
          /// Encapsulates shared try/catch blocks for all file types
          /// to hide std::exception.
       virtual void tryFFStreamGet(FFData& rec)
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
 
          /// Encapsulates shared try/catch blocks for all file types
          /// to hide std::exception.
       virtual void tryFFStreamPut(const FFData& rec)
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
    private:
          /// Initialize internal data structures according to file name & mode
@@ -207,7 +207,7 @@ namespace gpstk
 
 
    void FFStream ::
-   conditionalThrow(void) throw(FFStreamError)
+   conditionalThrow(void) noexcept(false)
    {
       if (exceptions() & std::fstream::failbit)
       {

--- a/core/lib/FileHandling/FFTextStream.cpp
+++ b/core/lib/FileHandling/FFTextStream.cpp
@@ -100,7 +100,7 @@ namespace gpstk
 
    void FFTextStream ::
    tryFFStreamGet(FFData& rec)
-      throw(FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       unsigned int initialLineNumber = lineNumber;
 
@@ -121,7 +121,7 @@ namespace gpstk
 
    void FFTextStream ::
    tryFFStreamPut(const FFData& rec)
-      throw(FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       unsigned int initialLineNumber = lineNumber;
 
@@ -148,7 +148,7 @@ namespace gpstk
    void FFTextStream ::
    formattedGetLine( std::string& line,
                      const bool expectEOF )
-      throw(EndOfFile, FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/FileHandling/FFTextStream.hpp
+++ b/core/lib/FileHandling/FFTextStream.hpp
@@ -115,18 +115,18 @@ namespace gpstk
           */
       void formattedGetLine( std::string& line,
                              const bool expectEOF = false )
-         throw(EndOfFile, FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
 
    protected:
 
          /// calls FFStream::tryFFStreamGet and adds line number information
       virtual void tryFFStreamGet(FFData& rec)
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /// calls FFStream::tryFFStreamPut and adds line number information
       virtual void tryFFStreamPut(const FFData& rec)
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
    private:
          /// Initialize internal data structures

--- a/core/lib/FileHandling/RINEX/RinexClockBase.cpp
+++ b/core/lib/FileHandling/RINEX/RinexClockBase.cpp
@@ -80,7 +80,7 @@ namespace gpstk
 
    
    CivilTime RinexClockBase::parseTime(const string& line) const
-      throw(FFStreamError)
+      noexcept(false)
    {
       if ( line.size() != 26 )
       {

--- a/core/lib/FileHandling/RINEX/RinexClockBase.hpp
+++ b/core/lib/FileHandling/RINEX/RinexClockBase.hpp
@@ -105,7 +105,7 @@ namespace gpstk
          /// "yyyy mm dd hh mm ss.ssssss" to a CivilTime object.
          /// If the string is blank a CommonTime::BEGINNING_OF_TIME is returned.
       CivilTime parseTime(const std::string& line) const
-         throw(FFStreamError);
+         noexcept(false);
       
    };  //  RinexClockBase
       //@}

--- a/core/lib/FileHandling/RINEX/RinexClockData.cpp
+++ b/core/lib/FileHandling/RINEX/RinexClockData.cpp
@@ -76,8 +76,7 @@ namespace gpstk
 
    
    void RinexClockData::reallyPutRecord(FFStream& s) const
-      throw(std::exception, FFStreamError,
-            StringUtils::StringException)
+      noexcept(false)
    {      
       if ( type != AR &&
            type != AS &&
@@ -132,8 +131,7 @@ namespace gpstk
 
 
    void RinexClockData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError,
-            StringUtils::StringException)
+      noexcept(false)
    {
       RinexClockStream& strm = dynamic_cast<RinexClockStream&>(ffs);
 

--- a/core/lib/FileHandling/RINEX/RinexClockData.hpp
+++ b/core/lib/FileHandling/RINEX/RinexClockData.hpp
@@ -103,14 +103,12 @@ namespace gpstk
    protected:
          /// Writes a correctly formatted record from this data to stream
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
       
          
          /// This functions obtains a RINEX Clock record from the given stream
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
       
    }; // class RinexClockData
    

--- a/core/lib/FileHandling/RINEX/RinexClockHeader.cpp
+++ b/core/lib/FileHandling/RINEX/RinexClockHeader.cpp
@@ -286,7 +286,7 @@ namespace gpstk
 
 
    void RinexClockHeader::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       RinexClockStream& strm = dynamic_cast<RinexClockStream&>(ffs);
 
@@ -501,8 +501,7 @@ namespace gpstk
 
       // This function parses the entire header from the given stream
    void RinexClockHeader::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError,
-            StringUtils::StringException)
+      noexcept(false)
    {
       RinexClockStream& strm = dynamic_cast<RinexClockStream&>(ffs);
 
@@ -550,7 +549,7 @@ namespace gpstk
 
       // this function parses a single header record
    void RinexClockHeader::ParseHeaderRecord(const string& line)
-      throw(FFStreamError)
+      noexcept(false)
    {
       string label(line, 60, 20);
 

--- a/core/lib/FileHandling/RINEX/RinexClockHeader.hpp
+++ b/core/lib/FileHandling/RINEX/RinexClockHeader.hpp
@@ -217,7 +217,7 @@ namespace gpstk
    protected:
          /// outputs this record to the stream correctly formatted.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError, StringUtils::StringException);
+         noexcept(false);
       
          /**
           * This function retrieves the RINEX Clock Header from the 
@@ -230,7 +230,7 @@ namespace gpstk
           * stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,StringUtils::StringException);
+         noexcept(false);
 
          /// Clears all header values and lists.
       void clear();
@@ -242,7 +242,7 @@ namespace gpstk
           * Used by reallyGetRecord
           */
       void ParseHeaderRecord(const std::string& line)
-         throw(FFStreamError);
+         noexcept(false);
     
    }; // RinexClockHeader
 

--- a/core/lib/FileHandling/RINEX/RinexMetData.cpp
+++ b/core/lib/FileHandling/RINEX/RinexMetData.cpp
@@ -54,8 +54,7 @@ namespace gpstk
    const int RinexMetData::maxObsPerContinuationLine = 10;
 
    void RinexMetData::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, 
-            gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       RinexMetStream& strm = dynamic_cast<RinexMetStream&>(ffs);
       string line;
@@ -109,8 +108,7 @@ namespace gpstk
    }
 
    void RinexMetData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, 
-            gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       RinexMetStream& strm = dynamic_cast<RinexMetStream&>(ffs);
 
@@ -152,7 +150,7 @@ namespace gpstk
    void RinexMetData::processFirstLine(const string& line,
                                        const RinexMetHeader& hdr,
                                        double version)
-      throw(FFStreamError)
+      noexcept(false)
    {
       int yrLen = 18;
       if(version >= 3.02)
@@ -178,7 +176,7 @@ namespace gpstk
 
    void RinexMetData::processContinuationLine(const string& line,
                                               const RinexMetHeader& hdr)
-      throw(FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -200,7 +198,7 @@ namespace gpstk
    }
 
    CommonTime RinexMetData::parseTime(const string& line, double version) const
-      throw(FFStreamError)
+      noexcept(false)
    {
       int addYrLen = 0;
       if(version >=3.02)
@@ -258,7 +256,7 @@ namespace gpstk
    }
 
    string RinexMetData::writeTime(const CommonTime& dt, double version) const
-      throw(StringException)
+      noexcept(false)
    {
       int yrLen = 2;
       if(version >= 3.02)

--- a/core/lib/FileHandling/RINEX/RinexMetData.hpp
+++ b/core/lib/FileHandling/RINEX/RinexMetData.hpp
@@ -110,8 +110,7 @@ namespace gpstk
 
          /// Writes the met data to the file stream formatted correctly.
       void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function retrieves a RINEX 2 or 3 Met record from the
@@ -124,8 +123,7 @@ namespace gpstk
           *         stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
    private:
 
@@ -134,23 +132,23 @@ namespace gpstk
       void processFirstLine(const std::string& line,
                             const RinexMetHeader& hdr,
                             double version)
-         throw(FFStreamError);
+         noexcept(false);
 
          /// Parses string \a line to get data on continuation lines.
       void processContinuationLine(const std::string& line,
                                    const RinexMetHeader& hdr)
-         throw(FFStreamError);
+         noexcept(false);
 
          /// Parses the time portion of a line into a CommonTime object.
          /// @param version of Rinex file (3.02, 3.01, 2.11, ...)
       CommonTime parseTime(const std::string& line, double version) const
-         throw(FFStreamError);
+         noexcept(false);
 
          /// Writes the CommonTime object into RINEX format. If it's a
          /// bad time, it will return blanks.
          /// @param version Rinex version, default to 2.11 for backwards compatability
       std::string writeTime(const CommonTime& dtd, double version = 2.11) const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
 
    };  // class RinexMetData
 

--- a/core/lib/FileHandling/RINEX/RinexMetHeader.cpp
+++ b/core/lib/FileHandling/RINEX/RinexMetHeader.cpp
@@ -88,8 +88,7 @@ namespace gpstk
    }
 
    void RinexMetHeader::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError,
-            gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       RinexMetStream& strm = dynamic_cast<RinexMetStream&>(ffs);
 
@@ -255,8 +254,7 @@ namespace gpstk
    }
 
    void RinexMetHeader::reallyGetRecord(FFStream& ffs) 
-      throw(std::exception, FFStreamError, 
-            gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       RinexMetStream& strm = dynamic_cast<RinexMetStream&>(ffs);
 
@@ -464,7 +462,7 @@ namespace gpstk
 
    RinexMetHeader::RinexMetType
    RinexMetHeader::convertObsType(const string& oneObs)
-      throw(FFStreamError)
+      noexcept(false)
    {
       if      (oneObs == "PR") return PR;
       else if (oneObs == "TD") return TD;
@@ -484,7 +482,7 @@ namespace gpstk
    }
 
    string RinexMetHeader::convertObsType(const RinexMetHeader::RinexMetType& oneObs)
-      throw(FFStreamError)
+      noexcept(false)
    {
       if      (oneObs == PR) return "PR";
       else if (oneObs == TD) return "TD";

--- a/core/lib/FileHandling/RINEX/RinexMetHeader.hpp
+++ b/core/lib/FileHandling/RINEX/RinexMetHeader.hpp
@@ -105,11 +105,11 @@ namespace gpstk
 
          /// sets the obs type array given an obs type line
       static RinexMetType convertObsType(const std::string& oneObs)
-         throw(FFStreamError);
+         noexcept(false);
 
          /// Converts a RinexMetType to its string equivalent.
       static std::string convertObsType(const RinexMetType& oneObs)
-         throw(FFStreamError);
+         noexcept(false);
 
          /// Tell me, Am I valid?
       unsigned long valid;
@@ -256,8 +256,7 @@ namespace gpstk
 
          /// Writes the RINEX Met header to the stream \a s.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function reads the RINEX MET header from the given FFStream.
@@ -269,8 +268,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
    }; // class RinexMetHeader
 

--- a/core/lib/FileHandling/RINEX/RinexNavData.cpp
+++ b/core/lib/FileHandling/RINEX/RinexNavData.cpp
@@ -104,7 +104,7 @@ namespace gpstk
    }
 
    void RinexNavData::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       RinexNavStream& strm = dynamic_cast<RinexNavStream&>(ffs);
 
@@ -127,7 +127,7 @@ namespace gpstk
    }
 
    void RinexNavData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       RinexNavStream& strm = dynamic_cast<RinexNavStream&>(ffs);
 
@@ -183,7 +183,7 @@ namespace gpstk
         << endl;
    }
 
-   RinexNavData::operator EngEphemeris() const throw()
+   RinexNavData::operator EngEphemeris() const noexcept
    {
       EngEphemeris ee;
 
@@ -317,7 +317,7 @@ namespace gpstk
    }
 
    string RinexNavData::putPRNEpoch(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += rightJustify(asString(PRNID), 2);
@@ -332,13 +332,13 @@ namespace gpstk
    }
 
    string RinexNavData::writeTime(const CommonTime& dt) const
-      throw(StringException)
+      noexcept(false)
    {
       return printTime(dt, " %02y %2m %2d %2H %2M%5.1f");
    }
 
    string RinexNavData::putBroadcastOrbit1(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -354,7 +354,7 @@ namespace gpstk
    }
 
    string RinexNavData::putBroadcastOrbit2(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -370,7 +370,7 @@ namespace gpstk
    }
 
    string RinexNavData::putBroadcastOrbit3(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -386,7 +386,7 @@ namespace gpstk
    }
 
    string RinexNavData::putBroadcastOrbit4(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -402,7 +402,7 @@ namespace gpstk
    }
 
    string RinexNavData::putBroadcastOrbit5(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -418,7 +418,7 @@ namespace gpstk
    }
 
    string RinexNavData::putBroadcastOrbit6(void) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -434,7 +434,7 @@ namespace gpstk
    }
 
    string RinexNavData::putBroadcastOrbit7(const double ver) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       line += string(3, ' ');
@@ -450,7 +450,7 @@ namespace gpstk
    }
 
    void RinexNavData::getPRNEpoch(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -498,7 +498,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit1(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -516,7 +516,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit2(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -534,7 +534,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit3(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -552,7 +552,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit4(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -570,7 +570,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit5(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -594,7 +594,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit6(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -617,7 +617,7 @@ namespace gpstk
    }
 
    void RinexNavData::getBroadcastOrbit7(const string& currentLine)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/FileHandling/RINEX/RinexNavData.hpp
+++ b/core/lib/FileHandling/RINEX/RinexNavData.hpp
@@ -98,7 +98,7 @@ namespace gpstk
          /**
           * Converts this RinexNavData to an EngEphemeris object.
           */
-      operator EngEphemeris() const throw();
+      operator EngEphemeris() const noexcept;
 
          /** Convert this RinexNavData to a GPSEphemeris object.  For
           * backward compatibility only - use Rinex3NavData. */
@@ -114,7 +114,7 @@ namespace gpstk
           * defined to be the epoch time of the record (RINEX 2.11
           * Table A4).
           */
-      CommonTime getTocTime() const throw()
+      CommonTime getTocTime() const noexcept
       { return time; }
 
          /**
@@ -252,64 +252,63 @@ namespace gpstk
    private:
          /// Writes the CommonTime object into RINEX format.
       std::string writeTime(const CommonTime& dt) const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Parses string \a currentLine to obtain PRN id and epoch.
       void getPRNEpoch(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 1 of the Nav Data record
       void getBroadcastOrbit1(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 2 of the Nav Data record
       void getBroadcastOrbit2(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 3 of the Nav Data record
       void getBroadcastOrbit3(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 4 of the Nav Data record
       void getBroadcastOrbit4(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 5 of the Nav Data record
       void getBroadcastOrbit5(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 6 of the Nav Data record
       void getBroadcastOrbit6(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
          /// Reads line 7 of the Nav Data record
       void getBroadcastOrbit7(const std::string& currentLine)
-         throw(gpstk::StringUtils::StringException, FFStreamError);
+         noexcept(false);
 
          /// generates a line to be output to a file for the PRN/epoch line
       std::string putPRNEpoch() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
       std::string putBroadcastOrbit1() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
       std::string putBroadcastOrbit2() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
       std::string putBroadcastOrbit3() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
       std::string putBroadcastOrbit4() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
       std::string putBroadcastOrbit5() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
       std::string putBroadcastOrbit6() const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
          /// Writes line 7 of the Nav Data record
          /// @warning Pass in version to decide wheter or not
          /// to write fit interval
       std::string putBroadcastOrbit7(const double ver) const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
 
    protected:
          /// Outputs the record to the FFStream \a s.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function retrieves a RINEX NAV record from the given FFStream.
@@ -321,8 +320,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
    };  // class RinexNavData
 
       //@}

--- a/core/lib/FileHandling/RINEX/RinexNavHeader.cpp
+++ b/core/lib/FileHandling/RINEX/RinexNavHeader.cpp
@@ -63,7 +63,7 @@ namespace gpstk
    const string RinexNavHeader::versionString = "RINEX VERSION / TYPE";
 
    void RinexNavHeader::reallyPutRecord(FFStream& ffs) const 
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       RinexNavStream& strm = dynamic_cast<RinexNavStream&>(ffs);
       
@@ -178,7 +178,7 @@ namespace gpstk
    }
 
    void RinexNavHeader::reallyGetRecord(FFStream& ffs) 
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       RinexNavStream& strm = dynamic_cast<RinexNavStream&>(ffs);
       

--- a/core/lib/FileHandling/RINEX/RinexNavHeader.hpp
+++ b/core/lib/FileHandling/RINEX/RinexNavHeader.hpp
@@ -124,8 +124,7 @@ namespace gpstk
    protected:
          /// Writes a correctly formatted record from this data to stream \a s.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError, 
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function reads the RINEX NAV header from the given FFStream.
@@ -137,8 +136,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s) 
-         throw(std::exception, FFStreamError, 
-               gpstk::StringUtils::StringException);
+         noexcept(false);
    }; // class RinexNavHeader
 
       //@}

--- a/core/lib/FileHandling/RINEX/RinexObsData.cpp
+++ b/core/lib/FileHandling/RINEX/RinexObsData.cpp
@@ -54,7 +54,7 @@ namespace gpstk
    CommonTime gpstk::RinexObsData::previousTime;
 
    void RinexObsData::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       // is there anything to write?
       if( (epochFlag==0 || epochFlag==1 || epochFlag==6)
@@ -179,7 +179,7 @@ namespace gpstk
 
 
    void RinexObsData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       RinexObsStream& strm = dynamic_cast<RinexObsStream&>(ffs);
 
@@ -357,7 +357,7 @@ namespace gpstk
 
    CommonTime RinexObsData::parseTime(const string& line,
                                    const RinexObsHeader& hdr) const
-      throw(FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -417,7 +417,7 @@ namespace gpstk
    }
 
    string RinexObsData::writeTime(const CommonTime& dt) const
-      throw(StringException)
+      noexcept(false)
    {
       if (dt == CommonTime::BEGINNING_OF_TIME)
       {

--- a/core/lib/FileHandling/RINEX/RinexObsData.hpp
+++ b/core/lib/FileHandling/RINEX/RinexObsData.hpp
@@ -120,8 +120,7 @@ namespace gpstk
           * number for the type of header data you want to write.
           */
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This functions obtains a RINEX Observation record from the given
@@ -137,8 +136,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
    private:
          ///<Time corresponding to previous set of oberservations
@@ -148,7 +146,7 @@ namespace gpstk
          /// Writes the CommonTime object into RINEX format. If it's a bad time,
          /// it will return blanks.
       std::string writeTime(const CommonTime& dt) const
-         throw(gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function constructs a CommonTime object from the given parameters.
@@ -156,7 +154,7 @@ namespace gpstk
           * @param hdr the RINEX Observation Header object for the current RINEX file.
           */
       CommonTime parseTime(const std::string& line, const RinexObsHeader& hdr) const
-         throw(FFStreamError);
+         noexcept(false);
    }; // class RinexObsData
 
       //@}

--- a/core/lib/FileHandling/RINEX/RinexObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX/RinexObsHeader.cpp
@@ -141,7 +141,7 @@ namespace gpstk
       = RinexObsHeader::StandardRinexObsTypes;
 
    void RinexObsHeader::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       RinexObsStream& strm = dynamic_cast<RinexObsStream&>(ffs);
 
@@ -182,7 +182,7 @@ namespace gpstk
 
 
       // this function computes the number of valid header records which WriteHeaderRecords will write
-   int RinexObsHeader::NumberHeaderRecordsToBeWritten(void) const throw()
+   int RinexObsHeader::NumberHeaderRecordsToBeWritten(void) const noexcept
    {
       int n=0;
       if(valid & RinexObsHeader::versionValid) n++;
@@ -214,7 +214,7 @@ namespace gpstk
 
       // this function writes all valid header records
    void RinexObsHeader::WriteHeaderRecords(FFStream& ffs) const
-      throw(FFStreamError, StringException)
+      noexcept(false)
    {
       RinexObsStream& strm = dynamic_cast<RinexObsStream&>(ffs);
       string line;
@@ -516,7 +516,7 @@ namespace gpstk
 
       // this function parses a single header record
    void RinexObsHeader::ParseHeaderRecord(string& line)
-      throw(FFStreamError)
+      noexcept(false)
    {
       string label(line, 60, 20);
 
@@ -752,8 +752,7 @@ namespace gpstk
 
       // This function parses the entire header from the given stream
    void RinexObsHeader::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError,
-            gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       RinexObsStream& strm = dynamic_cast<RinexObsStream&>(ffs);
 
@@ -831,7 +830,7 @@ namespace gpstk
 
    RinexObsType
    RinexObsHeader::convertObsType(const string& oneObs)
-      throw(FFStreamError)
+      noexcept(false)
    {
       RinexObsType ot(RegisteredRinexObsTypes[0]);   // Unknown type
       for(size_t i=0; i<RegisteredRinexObsTypes.size(); i++) {
@@ -846,7 +845,7 @@ namespace gpstk
    }
    string
    RinexObsHeader::convertObsType(const RinexObsType& oneObs)
-      throw(FFStreamError)
+      noexcept(false)
    {
       return oneObs.type;
    }

--- a/core/lib/FileHandling/RINEX/RinexObsHeader.hpp
+++ b/core/lib/FileHandling/RINEX/RinexObsHeader.hpp
@@ -272,30 +272,30 @@ namespace gpstk
           * This function converts the string in \a oneObs to a RinexObsType.
           */
       static RinexObsType convertObsType(const std::string& oneObs)
-         throw(FFStreamError);
+         noexcept(false);
 
          /**
           * This function converts the RinexObsType in \a oneObs to a string.
           */
       static std::string convertObsType(const RinexObsType& oneObs)
-         throw(FFStreamError);
+         noexcept(false);
 
          /**
           * Parse a single header record, and modify valid accordingly.
           * Used by reallyGetRecord for both RinexObsHeader and RinexObsData.
           */
       void ParseHeaderRecord(std::string& line)
-         throw(FFStreamError);
+         noexcept(false);
 
          /// Compute the number of valid header records which WriteHeaderRecords() will write
-      int NumberHeaderRecordsToBeWritten(void) const throw();
+      int NumberHeaderRecordsToBeWritten(void) const noexcept;
 
          /**
           * Write all valid header records to the given stream.
           * Used by reallyPutRecord for both RinexObsHeader and RinexObsData.
           */
       void WriteHeaderRecords(FFStream& s) const
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /// Return boolean : is this a valid Rinex header?
       bool isValid() const { return ((valid & allValid20) == allValid20); }
@@ -305,8 +305,7 @@ namespace gpstk
           * outputs this record to the stream correctly formatted.
           */
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function retrieves the RINEX Header from the given FFStream.
@@ -318,8 +317,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
       friend class RinexObsData;
 

--- a/core/lib/FileHandling/RINEX/RinexUtilities.cpp
+++ b/core/lib/FileHandling/RINEX/RinexUtilities.cpp
@@ -342,7 +342,7 @@ bool isRinex3ObsFile(const string& file)
 }
 
 //------------------------------------------------------------------------------------
-string sortRinexObsFiles(vector<string>& files) throw(Exception)
+string sortRinexObsFiles(vector<string>& files) noexcept(false)
 {
 try {
    string msg;

--- a/core/lib/FileHandling/RINEX/RinexUtilities.hpp
+++ b/core/lib/FileHandling/RINEX/RinexUtilities.hpp
@@ -99,7 +99,7 @@ namespace gpstk
       /// headers.
       /// @param files  vector<string> containing filenames, with path
       /// @return string containing error messages, if any
-   std::string sortRinexObsFiles(std::vector<std::string>& files) throw(Exception);
+   std::string sortRinexObsFiles(std::vector<std::string>& files) noexcept(false);
 
       /// Sort a vector of RINEX 3 obs file names on the time of the
       /// first observation as found in the header. Return the sorted

--- a/core/lib/FileHandling/RINEX3/Rinex3ClockData.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ClockData.cpp
@@ -50,7 +50,7 @@ using namespace std;
 namespace gpstk
 {
    void Rinex3ClockData::reallyPutRecord(FFStream& ffs) const 
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       // cast the stream to be an Rinex3ClockStream
       Rinex3ClockStream& strm = dynamic_cast<Rinex3ClockStream&>(ffs);
@@ -116,7 +116,7 @@ namespace gpstk
    }  // end reallyPutRecord()
 
    void Rinex3ClockData::reallyGetRecord(FFStream& ffs)
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       // cast the stream to be an Rinex3ClockStream
       Rinex3ClockStream& strm = dynamic_cast<Rinex3ClockStream&>(ffs);
@@ -173,7 +173,7 @@ namespace gpstk
 
    }   // end reallyGetRecord()
 
-   void Rinex3ClockData::dump(ostream& s) const throw()
+   void Rinex3ClockData::dump(ostream& s) const noexcept
    {
       // dump record type, sat id / site, current epoch, and data
       s << " " << datatype;

--- a/core/lib/FileHandling/RINEX3/Rinex3ClockData.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ClockData.hpp
@@ -95,7 +95,7 @@ namespace gpstk
       virtual bool isData() const {return true;}
 
          /// Debug output function.
-      virtual void dump(std::ostream& s=std::cout) const throw();
+      virtual void dump(std::ostream& s=std::cout) const noexcept;
 
       std::string datatype;   ///< Data type : AR, AS, etc
       RinexSatID sat;         ///< Satellite ID        (if AS)
@@ -110,7 +110,7 @@ namespace gpstk
       
    protected:
 
-      void clear(void) throw()
+      void clear(void) noexcept
       {
          datatype = std::string();
          sat = RinexSatID(-1,RinexSatID::systemGPS);
@@ -121,8 +121,7 @@ namespace gpstk
          /// Writes the formatted record to the FFStream \a s.
          /// @warning This function is currently unimplemented
       virtual void reallyPutRecord(FFStream& s) const 
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function reads a record from the given FFStream.
@@ -134,8 +133,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s) 
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
    };
 
       //@}

--- a/core/lib/FileHandling/RINEX3/Rinex3ClockHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ClockHeader.cpp
@@ -76,7 +76,7 @@ namespace gpstk
 
       // --------------------------------------------------------------------------------
    void Rinex3ClockHeader::reallyGetRecord(FFStream& ffs)
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       Rinex3ClockStream& strm = dynamic_cast<Rinex3ClockStream&>(ffs);
       
@@ -265,7 +265,7 @@ namespace gpstk
 
 
    void Rinex3ClockHeader::reallyPutRecord(FFStream& ffs) const
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       try {
          Rinex3ClockStream& strm = dynamic_cast<Rinex3ClockStream&>(ffs);
@@ -493,7 +493,7 @@ namespace gpstk
    }
 
 
-   void Rinex3ClockHeader::dump(ostream& os, short detail) const throw()
+   void Rinex3ClockHeader::dump(ostream& os, short detail) const noexcept
    {
       size_t i;
       os << "Dump Rinex3Clock Header:\n";
@@ -553,7 +553,7 @@ namespace gpstk
 
    }  // end Rinex3ClockHeader::dump()
 
-   void Rinex3ClockHeader::dumpValid(ostream& os) const throw()
+   void Rinex3ClockHeader::dumpValid(ostream& os) const noexcept
    {
       if( (valid & allValid) == allValid) return;
       string tag("  Invalid or missing header line: ");

--- a/core/lib/FileHandling/RINEX3/Rinex3ClockHeader.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ClockHeader.hpp
@@ -140,11 +140,11 @@ namespace gpstk
           *    2: above plus all invalid header strings (dumpValid) */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverloaded-virtual"
-      virtual void dump(std::ostream& s=std::cout, short detail = 0) const throw();
+      virtual void dump(std::ostream& s=std::cout, short detail = 0) const noexcept;
 #pragma clang diagnostic pop
 
          /// Dump validity bits -> header strings
-      void dumpValid(std::ostream& s=std::cout) const throw();
+      void dumpValid(std::ostream& s=std::cout) const noexcept;
 
       double version;                        ///< Rinex3Clock Version or file format
       std::string program;                   ///< Program name
@@ -215,8 +215,7 @@ namespace gpstk
          /// Writes the record formatted to the FFStream \a s.
          /// @throws StringException when a StringUtils function fails
       virtual void reallyPutRecord(FFStream& s) const 
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
          /** This function retrieves the Rinex3Clock header from the
           * given FFStream.  If an error is encountered in the
@@ -227,8 +226,7 @@ namespace gpstk
           *  a read or formatting error occurs.  This also resets the
           *  stream to its pre-read position. */
       virtual void reallyGetRecord(FFStream& s) 
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
    }; // end class Rinex3ClockHeader
 

--- a/core/lib/FileHandling/RINEX3/Rinex3NavData.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavData.cpp
@@ -324,7 +324,7 @@ namespace gpstk
        *          to its pre-read position.
        */
    void Rinex3NavData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
 
       try {
@@ -367,7 +367,7 @@ namespace gpstk
 
       // Outputs the record to the FFStream \a s.
    void Rinex3NavData::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
 
       try {
@@ -474,7 +474,7 @@ namespace gpstk
 
       // Deprecated; use GPSEphemeris.
       // Converts this Rinex3NavData to an EngEphemeris object.
-   Rinex3NavData::operator EngEphemeris() const throw()
+   Rinex3NavData::operator EngEphemeris() const noexcept
    {
       EngEphemeris ee;
 
@@ -618,7 +618,7 @@ namespace gpstk
    }
 
       // Casts Rinex3NavData to a GPSEphemeris object.
-   Rinex3NavData::operator GPSEphemeris() const throw()
+   Rinex3NavData::operator GPSEphemeris() const noexcept
    {
       GPSEphemeris gpse;
 
@@ -689,7 +689,7 @@ namespace gpstk
    }
 
       // Casts this Rinex3NavData to a GloEphemeris object.
-   Rinex3NavData::operator GloEphemeris() const throw()
+   Rinex3NavData::operator GloEphemeris() const noexcept
    {
 
       GloEphemeris gloe;
@@ -712,7 +712,7 @@ namespace gpstk
    }  // End of 'Rinex3NavData::operator GloEphemeris()'
 
       // Casts Rinex3NavData to a GalEphemeris object.
-   Rinex3NavData::operator GalEphemeris() const throw()
+   Rinex3NavData::operator GalEphemeris() const noexcept
    {
       GalEphemeris gale;
 
@@ -763,7 +763,7 @@ namespace gpstk
    }
 
       // Casts Rinex3NavData to a BDSEphemeris object.
-   Rinex3NavData::operator BDSEphemeris() const throw()
+   Rinex3NavData::operator BDSEphemeris() const noexcept
    {
       BDSEphemeris bdse;
 
@@ -809,7 +809,7 @@ namespace gpstk
    }
 
       // Casts Rinex3NavData to a QZSEphemeris object.
-   Rinex3NavData::operator QZSEphemeris() const throw()
+   Rinex3NavData::operator QZSEphemeris() const noexcept
    {
       QZSEphemeris qzse;
 
@@ -914,7 +914,7 @@ namespace gpstk
        *  @param strm RINEX Nav stream
        */
    void Rinex3NavData::putPRNEpoch(Rinex3NavStream& strm) const
-      throw(StringException)
+      noexcept(false)
    {
       string line;
       CivilTime civtime(time);
@@ -972,7 +972,7 @@ namespace gpstk
       //                               after the epoch line.
       //  @param Rinex3NavStream strm  Stream to read from.
    void Rinex3NavData::putRecord(const int& nline, Rinex3NavStream& strm) const
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
 
       if(nline < 1 || nline > 7) {
@@ -1128,7 +1128,7 @@ namespace gpstk
 
 
    void Rinex3NavData::getPRNEpoch(Rinex3NavStream& strm)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       try {
          int i;
@@ -1232,7 +1232,7 @@ namespace gpstk
 
 
    void Rinex3NavData::getRecord(const int& nline, Rinex3NavStream& strm)
-      throw(StringException, FFStreamError)
+      noexcept(false)
    {
       if(nline < 1 || nline > 7) {
          FFStreamError fse(string("Invalid line number ") + asString(nline));

--- a/core/lib/FileHandling/RINEX3/Rinex3NavData.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavData.hpp
@@ -117,22 +117,22 @@ namespace gpstk
 
          /// deprecated; use GPSEphemeris, GPS-only.
          /// Converts Rinex3NavData to an EngEphemeris object.
-      operator EngEphemeris() const throw();
+      operator EngEphemeris() const;// noexcept;
 
          /// Converts Rinex3NavData to a GPSEphemeris object.
-      operator GPSEphemeris() const throw();
+      operator GPSEphemeris() const;// noexcept;
 
          /// Converts this Rinex3NavData to a GloEphemeris object.
-      operator GloEphemeris() const throw();
+      operator GloEphemeris() const;// noexcept;
 
          /// Converts Rinex3NavData to a GalEphemeris object.
-      operator GalEphemeris() const throw();
+      operator GalEphemeris() const;// noexcept;
 
          /// Converts Rinex3NavData to a BDSEphemeris object.
-      operator BDSEphemeris() const throw();
+      operator BDSEphemeris() const;// noexcept;
 
          /// Converts Rinex3NavData to a QZSEphemeris object.
-      operator QZSEphemeris() const throw();
+      operator QZSEphemeris() const;// noexcept;
 
          /// Converts the (non-CommonTime) data to an easy list
          /// for comparison operators.
@@ -247,7 +247,7 @@ namespace gpstk
           *  @param strm RINEX Nav stream
           */
       void getPRNEpoch(Rinex3NavStream& strm)
-         throw(StringUtils::StringException, FFStreamError);
+         noexcept(false);
 
 
          /**  Read and parse the nth record after the epoch record
@@ -256,13 +256,13 @@ namespace gpstk
           *   @param Rinex3NavStream strm stream to read from
           */
       void getRecord(const int& n, Rinex3NavStream& strm)
-         throw(StringUtils::StringException, FFStreamError);
+         noexcept(false);
 
          /** Generates the PRN/epoch line and outputs it to strm
           *  @param strm RINEX Nav stream
           */
       void putPRNEpoch(Rinex3NavStream& strm) const
-         throw(StringUtils::StringException);
+         noexcept(false);
 
 
          /** Construct and write the nth record after the epoch record
@@ -271,7 +271,7 @@ namespace gpstk
           *  @param Rinex3NavStream strm  Stream to read from.
           */
       void putRecord(const int& n, Rinex3NavStream& strm) const
-         throw(StringUtils::StringException, FFStreamError);
+         noexcept(false);
 
          /** Helper routine for constructors of this from
           * OrbitEph-based Ephemerides */
@@ -292,12 +292,12 @@ namespace gpstk
           *          to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError, StringUtils::StringException);
+         noexcept(false);
 
 
          /// Outputs the record to the FFStream \a s.
       virtual void reallyPutRecord(FFStream& s) const 
-         throw(std::exception, FFStreamError, StringUtils::StringException);
+         noexcept(false);
 
    }; // End of class 'Rinex3NavData'
 

--- a/core/lib/FileHandling/RINEX3/Rinex3NavHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavHeader.cpp
@@ -96,7 +96,7 @@ namespace gpstk
 
 
    std::string IonoCorr ::
-   asString() const throw()
+   asString() const noexcept
    {
       switch(type)
       {
@@ -111,7 +111,7 @@ namespace gpstk
 
 
    void IonoCorr ::
-   fromString(const std::string str) throw(Exception)
+   fromString(const std::string str) noexcept(false)
    {
       std::string STR(gpstk::StringUtils::upperCase(str));
       if (STR == std::string("GAL"))
@@ -160,7 +160,7 @@ namespace gpstk
 
 
    void Rinex3NavHeader::reallyGetRecord(FFStream& ffs) 
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       Rinex3NavStream& strm = dynamic_cast<Rinex3NavStream&>(ffs);
    
@@ -447,7 +447,7 @@ namespace gpstk
 
       //-----------------------------------------------------------------------
    void Rinex3NavHeader::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       Rinex3NavStream& strm = dynamic_cast<Rinex3NavStream&>(ffs);
 
@@ -784,7 +784,7 @@ namespace gpstk
 
 
    void Rinex3NavHeader::setFileSystem(const std::string& str)
-      throw(Exception)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/FileHandling/RINEX3/Rinex3NavHeader.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavHeader.hpp
@@ -79,10 +79,10 @@ namespace gpstk
       IonoCorr(std::string str);
 
          /// Return string version of CorrType
-      std::string asString() const throw();
+      std::string asString() const noexcept;
 
          /// Set type value from RINEX correction type string.
-      void fromString(const std::string str) throw(Exception);
+      void fromString(const std::string str) noexcept(false);
 
          /// Equality test
       bool operator==(const IonoCorr& ic) const;
@@ -124,7 +124,7 @@ namespace gpstk
           * consistent.
           * @param[in] string str beginning with system character or
           *   "M" for mixed */
-      void setFileSystem(const std::string& str) throw(Exception);
+      void setFileSystem(const std::string& str) noexcept(false);
 
          /** Compare this header with another.
           * @param[in] right the header to compare this with.
@@ -205,9 +205,7 @@ namespace gpstk
          //// Protected member functions
          /// Write this header to stream \a s.
       virtual void reallyPutRecord(FFStream& s) const
-         throw( std::exception,
-                FFStreamError,
-                gpstk::StringUtils::StringException );
+         noexcept(false);
 
 
          /// This function reads the RINEX Nav header from the given FFStream.
@@ -218,9 +216,7 @@ namespace gpstk
          ///         or formatting error occurs.  This also resets the stream
          ///         to its pre-read position.
       virtual void reallyGetRecord(FFStream& s)
-         throw( std::exception,
-                FFStreamError,
-                gpstk::StringUtils::StringException );
+         noexcept(false);
 
    }; // End of class 'Rinex3NavHeader'
 

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsData.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsData.cpp
@@ -53,7 +53,7 @@ namespace gpstk
 {
    void reallyPutRecordVer2( Rinex3ObsStream& strm,
                              const Rinex3ObsData& rod )
-      throw(FFStreamError, StringException)
+      noexcept(false)
    {
          // is there anything to write?
       if( (rod.epochFlag==0 || rod.epochFlag==1 || rod.epochFlag==6)
@@ -220,7 +220,7 @@ namespace gpstk
 
 
    RinexDatum Rinex3ObsData::getObs(const RinexSatID& svID, size_t index ) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       DataMap::const_iterator i = obs.find(svID);
       if (i == obs.end())
@@ -241,7 +241,7 @@ namespace gpstk
    RinexDatum Rinex3ObsData::getObs(const RinexSatID& svID,
                                     const std::string& type,
                                     const Rinex3ObsHeader& hdr ) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       string obsID;
          // Add GNSS code if needed
@@ -257,7 +257,7 @@ namespace gpstk
    RinexDatum Rinex3ObsData::getObs(const RinexSatID& svID,
                                     const RinexObsID& obsID,
                                     const Rinex3ObsHeader& hdr ) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       string sys(1,svID.systemChar());
       return getObs(svID, hdr.getObsIndex(sys, obsID));
@@ -268,7 +268,7 @@ namespace gpstk
                               const RinexSatID& svID,
                               const RinexObsID& obsID,
                               const Rinex3ObsHeader& hdr )
-         throw(InvalidRequest)
+         noexcept(false)
    {
       size_t index = hdr.getObsIndex(string(1,svID.systemChar()), obsID);
       if (obs[svID].size() <= index)
@@ -278,7 +278,7 @@ namespace gpstk
 
    
    void Rinex3ObsData::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
          // is there anything to write?
       if( (epochFlag == 0 || epochFlag == 1 || epochFlag == 6)
@@ -360,7 +360,7 @@ namespace gpstk
 
    
    void reallyGetRecordVer2(Rinex3ObsStream& strm, Rinex3ObsData& rod)
-      throw(Exception)
+      noexcept(false)
    {
       static CommonTime previousTime(CommonTime::BEGINNING_OF_TIME);
 
@@ -574,7 +574,7 @@ namespace gpstk
 
 
    void Rinex3ObsData::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       Rinex3ObsStream& strm = dynamic_cast<Rinex3ObsStream&>(ffs);
 
@@ -710,7 +710,7 @@ namespace gpstk
    CommonTime Rinex3ObsData::parseTime(const string& line,
                                        const Rinex3ObsHeader& hdr,
                                        const TimeSystem& ts) const
-      throw(FFStreamError)
+      noexcept(false)
    {
       try
       {
@@ -767,7 +767,7 @@ namespace gpstk
    }  // end parseTime
 
    string Rinex3ObsData::writeTime(const CommonTime& ct) const
-      throw(StringException)
+      noexcept(false)
    {
       if(ct == CommonTime::BEGINNING_OF_TIME)
          return string(26, ' ');
@@ -790,7 +790,7 @@ namespace gpstk
       return line;
    }  // end writeTime
 
-   string Rinex3ObsData::timeString() const throw(StringException)
+   string Rinex3ObsData::timeString() const noexcept(false)
    {
       return writeTime(time);
    }

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsData.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsData.hpp
@@ -113,7 +113,7 @@ namespace gpstk
           *                using method 'Rinex3ObsHeader::getObsIndex()'.
           */
       virtual RinexDatum getObs( const RinexSatID& svID, size_t index ) const
-         throw(InvalidRequest);
+         noexcept(false);
 
 
          /** This method returns the RinexDatum of a given observation
@@ -125,7 +125,7 @@ namespace gpstk
       virtual RinexDatum getObs( const RinexSatID& svID,
                                  const std::string& obsID,
                                  const Rinex3ObsHeader& hdr ) const
-         throw(InvalidRequest);
+         noexcept(false);
 
          /** This method returns the RinexDatum of a given observation
           *
@@ -136,7 +136,7 @@ namespace gpstk
       virtual RinexDatum getObs( const RinexSatID& svID,
                                  const RinexObsID& obsID,
                                  const Rinex3ObsHeader& hdr ) const
-         throw(InvalidRequest);
+         noexcept(false);
 
          /** This sets the RinexDatum for a given observation
           *
@@ -149,7 +149,7 @@ namespace gpstk
                            const RinexSatID& svID,
                            const RinexObsID& obsID,
                            const Rinex3ObsHeader& hdr )
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// A Debug output function.
          /// Dumps the time of observations and the IDs of the Sats
@@ -161,7 +161,7 @@ namespace gpstk
       void dump(std::ostream& s, Rinex3ObsHeader& head) const;
 
       std::string timeString() const
-         throw( gpstk::StringUtils::StringException );
+         noexcept(false);
 
    protected:
 
@@ -174,8 +174,7 @@ namespace gpstk
          /// Also, make sure to correctly set the epochFlag to the correct
          /// number for the type of header data you want to write.
       virtual void reallyPutRecord(FFStream& s) const
-         throw( std::exception, FFStreamError,
-                gpstk::StringUtils::StringException );
+         noexcept(false);
 
 
          /** This functions obtains a RINEX 3 Observation record from the given
@@ -192,8 +191,7 @@ namespace gpstk
           *          pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw( std::exception, FFStreamError,
-                gpstk::StringUtils::StringException );
+         noexcept(false);
 
 
    private:
@@ -202,7 +200,7 @@ namespace gpstk
          /// Writes the CommonTime into RINEX 3 format.
          /// If it's a bad time, it will return blanks.
       std::string writeTime(const CommonTime& dt) const
-         throw( gpstk::StringUtils::StringException );
+         noexcept(false);
 
 
          /** This function constructs a CommonTime object from the given
@@ -215,7 +213,7 @@ namespace gpstk
       CommonTime parseTime( const std::string& line,
                             const Rinex3ObsHeader& hdr,
                             const TimeSystem& ts) const
-         throw( FFStreamError );
+         noexcept(false);
 
 
    }; // End of class 'Rinex3ObsData'

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -169,7 +169,7 @@ namespace gpstk
 
 
    void Rinex3ObsHeader::reallyPutRecord(FFStream& ffs) const
-      throw(std::exception, FFStreamError, StringException)
+      noexcept(false)
    {
       Rinex3ObsStream& strm = dynamic_cast<Rinex3ObsStream&>(ffs);
 
@@ -252,7 +252,7 @@ namespace gpstk
       // This function computes the number of valid header records
       // which writeHeaderRecords will write.
       // NB not used in Rinex3Obs....
-   int Rinex3ObsHeader::numberHeaderRecordsToBeWritten(void) const throw()
+   int Rinex3ObsHeader::numberHeaderRecordsToBeWritten(void) const noexcept
    {
       int n = 0;
 
@@ -305,7 +305,7 @@ namespace gpstk
 
       // This function writes all valid header records.
    void Rinex3ObsHeader::writeHeaderRecords(FFStream& ffs) const
-      throw(FFStreamError, StringException)
+      noexcept(false)
    {
       Rinex3ObsStream& strm = dynamic_cast<Rinex3ObsStream&>(ffs);
       string line;
@@ -1000,7 +1000,7 @@ namespace gpstk
 
       // This function parses a single header record.
    void Rinex3ObsHeader::parseHeaderRecord(string& line)
-      throw(FFStreamError)
+      noexcept(false)
    {
       int i;
       string label(line, 60, 20);
@@ -1507,8 +1507,7 @@ namespace gpstk
 
       // This function parses the entire header from the given stream
    void Rinex3ObsHeader::reallyGetRecord(FFStream& ffs)
-      throw(std::exception, FFStreamError, 
-            gpstk::StringUtils::StringException)
+      noexcept(false)
    {
       Rinex3ObsStream& strm = dynamic_cast<Rinex3ObsStream&>(ffs);
 
@@ -1737,7 +1736,7 @@ namespace gpstk
       // Since only GPS and only v2.11 are of interest, only L1/L2/L5
       // are considered.
    vector<RinexObsID> Rinex3ObsHeader::mapR2ObsToR3Obs_G()
-      throw(FFStreamError)
+      noexcept(false)
    {
       vector<RinexObsID> obsids;
        
@@ -1857,7 +1856,7 @@ namespace gpstk
       // Since only GLONASS and only v2.11 are of interest, only L1/L2
       // are considered.
    vector<RinexObsID> Rinex3ObsHeader::mapR2ObsToR3Obs_R( )
-      throw(FFStreamError)
+      noexcept(false)
    {
       vector<RinexObsID> obsids;
       
@@ -1917,7 +1916,7 @@ namespace gpstk
       // Given the current lack of experience, the code makes some 
       // guesses on what the v2.11 translations should mean.   
    vector<RinexObsID> Rinex3ObsHeader::mapR2ObsToR3Obs_E()
-      throw(FFStreamError)
+      noexcept(false)
    {
       vector<RinexObsID> obsids;
 
@@ -1980,7 +1979,7 @@ namespace gpstk
       // Since only SBAS and only v2.11 are of interest only L1/L5
       // are considered.
    vector<RinexObsID> Rinex3ObsHeader::mapR2ObsToR3Obs_S()
-      throw(FFStreamError)
+      noexcept(false)
    {
       vector<RinexObsID> obsids;
 
@@ -2405,7 +2404,7 @@ namespace gpstk
        * @param type String representing the observation type.
        */
    size_t Rinex3ObsHeader::getObsIndex( const string& type ) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       string newType(type);
 
@@ -2450,7 +2449,7 @@ namespace gpstk
    
    size_t Rinex3ObsHeader::getObsIndex(const string& sys,
                                        const RinexObsID& obsID ) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
          /// typedef std::vector<RinexObsID> RinexObsVec;
          /// typedef std::map<std::string, RinexObsVec> RinexObsMap;

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.hpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.hpp
@@ -417,7 +417,7 @@ namespace gpstk
           * @param[in] type String representing the observation type.
           */
       virtual std::size_t getObsIndex(const std::string& type ) const
-         throw(InvalidRequest);
+         noexcept(false);
 
          /** This method returns the numerical index of a given observation
           *
@@ -425,23 +425,23 @@ namespace gpstk
           * @param[in] obsID RinexObsID of the observation
           */
       virtual std::size_t getObsIndex(const std::string& sys, const RinexObsID& obsID ) const
-         throw(InvalidRequest);
+         noexcept(false);
 
          /** Parse a single header record, and modify valid
           * accordingly.  Used by reallyGetRecord for both
           * Rinex3ObsHeader and Rinex3ObsData. */
       void parseHeaderRecord(std::string& line)
-         throw(FFStreamError);
+         noexcept(false);
 
          /** Compute number of valid header records that
           * writeHeaderRecords() will write */
-      int numberHeaderRecordsToBeWritten(void) const throw();
+      int numberHeaderRecordsToBeWritten(void) const noexcept;
 
          /** Write all valid header records to the given stream.  Used
           * by reallyPutRecord for both Rinex3ObsHeader and
           * Rinex3ObsData. */
       void writeHeaderRecords(FFStream& s) const
-         throw(FFStreamError, gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /// Return boolean : is this a valid Rinex header?
       bool isValid() const
@@ -481,8 +481,7 @@ namespace gpstk
 
          /// outputs this record to the stream correctly formatted.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /** This function retrieves the RINEX Header from the given FFStream.
           * If an stream error is encountered, the stream is reset to its
@@ -492,8 +491,7 @@ namespace gpstk
           *  a read or formatting error occurs.  This also resets the
           *  stream to its pre-read position. */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
 
          /// Helper methods
@@ -502,10 +500,10 @@ namespace gpstk
          /// methods read the list of v2.11 obs types stored in R2ObsTypes
          /// and attempt to build a corresponding list of v3 observation
          /// types where appropriate.
-      std::vector<RinexObsID> mapR2ObsToR3Obs_G() throw(FFStreamError);
-      std::vector<RinexObsID> mapR2ObsToR3Obs_R() throw(FFStreamError);
-      std::vector<RinexObsID> mapR2ObsToR3Obs_E() throw(FFStreamError);
-      std::vector<RinexObsID> mapR2ObsToR3Obs_S() throw(FFStreamError);
+      std::vector<RinexObsID> mapR2ObsToR3Obs_G() noexcept(false);
+      std::vector<RinexObsID> mapR2ObsToR3Obs_R() noexcept(false);
+      std::vector<RinexObsID> mapR2ObsToR3Obs_E() noexcept(false);
+      std::vector<RinexObsID> mapR2ObsToR3Obs_S() noexcept(false);
 
       friend class Rinex3ObsData;
 

--- a/core/lib/FileHandling/SINEX/SinexBlock.hpp
+++ b/core/lib/FileHandling/SINEX/SinexBlock.hpp
@@ -87,7 +87,7 @@ namespace gpstk
              * @returns Number of lines written
              */
          virtual size_t putBlock(Sinex::Stream& s) const
-            throw(std::exception, FFStreamError, StringUtils::StringException) = 0;
+            noexcept(false) = 0;
 
             /**
              * Reads a record from the given SinexStream; if an error
@@ -101,7 +101,7 @@ namespace gpstk
              *  stream to its pre-read position.
              */
          virtual size_t getBlock(Sinex::Stream& s)
-            throw(std::exception, FFStreamError, StringUtils::StringException) = 0;
+            noexcept(false) = 0;
 
       }; // class BlockBase
 
@@ -137,7 +137,7 @@ namespace gpstk
             /** Writes all data in the block to the specified stream
              */
          virtual size_t putBlock(Sinex::Stream& s) const
-            throw(std::exception, FFStreamError)
+            noexcept(false)
          {
             size_t  lineNum = 0;
             typename std::vector<T>::const_iterator  i = dataVec.begin();
@@ -160,7 +160,7 @@ namespace gpstk
             /** Reads all data in a block from the specified stream
              */
          virtual size_t getBlock(Sinex::Stream& s)
-            throw(std::exception, FFStreamError, StringUtils::StringException)
+            noexcept(false)
          {
             size_t  lineNum = 0;
             char    c;

--- a/core/lib/FileHandling/SINEX/SinexData.cpp
+++ b/core/lib/FileHandling/SINEX/SinexData.cpp
@@ -117,7 +117,7 @@ namespace Sinex
 
    void
    Data::reallyPutRecord(FFStream& s) const
-      throw(std::exception, FFStreamError, StringUtils::StringException)
+      noexcept(false)
    {
       Sinex::Stream& strm = dynamic_cast<Sinex::Stream&>(s);
       try
@@ -156,7 +156,7 @@ namespace Sinex
 
    void
    Data::reallyGetRecord(FFStream& s)
-      throw(std::exception, FFStreamError, StringUtils::StringException)
+      noexcept(false)
    {
       Sinex::Stream&  strm = dynamic_cast<Sinex::Stream&>(s);
       bool    terminated = false;

--- a/core/lib/FileHandling/SINEX/SinexData.hpp
+++ b/core/lib/FileHandling/SINEX/SinexData.hpp
@@ -103,7 +103,7 @@ namespace gpstk
              * Writes the formatted record to the FFStream.
              */
          void reallyPutRecord(FFStream& s) const
-            throw(std::exception, FFStreamError, StringUtils::StringException);
+            noexcept(false);
 
             /**
              * This function reads a record from the given FFStream.
@@ -116,7 +116,7 @@ namespace gpstk
              *  stream to its pre-read position.
              */
          void reallyGetRecord(FFStream& s)
-            throw(std::exception, FFStreamError, StringUtils::StringException);
+            noexcept(false);
 
       }; // class Data
 

--- a/core/lib/FileHandling/SP3/SP3Data.cpp
+++ b/core/lib/FileHandling/SP3/SP3Data.cpp
@@ -50,7 +50,7 @@ using namespace std;
 namespace gpstk
 {
    void SP3Data::reallyGetRecord(FFStream& ffs)
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       // cast the stream to be an SP3Stream
       SP3Stream& strm = dynamic_cast<SP3Stream&>(ffs);
@@ -321,7 +321,7 @@ namespace gpstk
    }   // end reallyGetRecord()
 
    void SP3Data::reallyPutRecord(FFStream& ffs) const
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       string line;
 
@@ -410,7 +410,7 @@ namespace gpstk
 
    }  // end reallyPutRecord()
 
-   void SP3Data::dump(ostream& s, bool includeC) const throw()
+   void SP3Data::dump(ostream& s, bool includeC) const noexcept
    {
       // dump record type (PV*), sat id, and current epoch
       s << RecType << " " << static_cast<SP3SatID>(sat).toString() << " "

--- a/core/lib/FileHandling/SP3/SP3Data.hpp
+++ b/core/lib/FileHandling/SP3/SP3Data.hpp
@@ -111,7 +111,7 @@ namespace gpstk
          /// Debug output function.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverloaded-virtual"
-      virtual void dump(std::ostream& s=std::cout, bool includeC=true) const throw();
+      virtual void dump(std::ostream& s=std::cout, bool includeC=true) const noexcept;
 #pragma clang diagnostic pop
 
       char RecType;    ///< Data type indicator. P position, V velocity, * epoch
@@ -141,8 +141,7 @@ namespace gpstk
 
          /// Writes the formatted record to the FFStream \a s.
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
 
          /**
           * This function reads a record from the given FFStream.
@@ -154,8 +153,7 @@ namespace gpstk
           *  stream to its pre-read position.
           */
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               gpstk::StringUtils::StringException);
+         noexcept(false);
    };
 
       //@}

--- a/core/lib/FileHandling/SP3/SP3Header.cpp
+++ b/core/lib/FileHandling/SP3/SP3Header.cpp
@@ -54,7 +54,7 @@ namespace gpstk
    using namespace std;
 
    void SP3Header::reallyGetRecord(FFStream& ffs)
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
       SP3Stream& strm = dynamic_cast<SP3Stream&>(ffs);
 
@@ -292,7 +292,7 @@ namespace gpstk
 
 
    void SP3Header::reallyPutRecord(FFStream& ffs) const
-      throw(exception, FFStreamError, StringException)
+      noexcept(false)
    {
    try {
       SP3Stream& strm = dynamic_cast<SP3Stream&>(ffs);
@@ -515,7 +515,7 @@ namespace gpstk
    }
 
 
-   void SP3Header::dump(ostream& s) const throw()
+   void SP3Header::dump(ostream& s) const noexcept
    {
       s << "SP3 Header: version " << versionString() << " containing ";
       if(containsVelocity) s << "positions and velocities.";

--- a/core/lib/FileHandling/SP3/SP3Header.hpp
+++ b/core/lib/FileHandling/SP3/SP3Header.hpp
@@ -89,11 +89,11 @@ namespace gpstk
 
          /// access the version or file format
          /// @return the current Version
-      Version getVersion(void) const throw() { return version; }
+      Version getVersion(void) const noexcept { return version; }
 
          /// access the version or file format as a character
          /// @return a character version of the current Version
-      char versionChar(void) const throw()
+      char versionChar(void) const noexcept
       {
          return versionChar(version);
       }
@@ -101,7 +101,7 @@ namespace gpstk
          /// access the version or file format as a character
          /// @param ver SP3 version
          /// @return a character version of the current Version
-      static char versionChar(Version ver) throw()
+      static char versionChar(Version ver) noexcept
       {
          char ch;
          switch(ver) {
@@ -121,7 +121,7 @@ namespace gpstk
 
          /// access the version or file format as a string
          /// @return a string version of the current Version
-      std::string versionString(void) const throw()
+      std::string versionString(void) const noexcept
       {
          return versionString(version);
       }
@@ -129,7 +129,7 @@ namespace gpstk
          /// access the version or file format as a string
          /// @param ver SP3 version
          /// @return a string version of the current Version
-      static std::string versionString(Version ver) throw()
+      static std::string versionString(Version ver) noexcept
       {
          std::string str;
          switch(ver) {
@@ -151,7 +151,7 @@ namespace gpstk
          /// automatically sets the version in the SP3Header object that is read.
          /// @param ver the Version to be assigned to this header
          /// @return the current Version
-      Version setVersion(const Version ver) throw()
+      Version setVersion(const Version ver) noexcept
       {
          Version oldFormat = version;
          version = ver;
@@ -159,7 +159,7 @@ namespace gpstk
       }
 
          /// return a string with time system name
-      std::string timeSystemString() const throw()
+      std::string timeSystemString() const noexcept
       { return timeSystem.asString(); };
 
          // The next four lines is our common interface
@@ -167,7 +167,7 @@ namespace gpstk
       virtual bool isHeader() const { return true; }
 
          /// Dump contents to an ostream
-      virtual void dump(std::ostream& s=std::cout) const throw();
+      virtual void dump(std::ostream& s=std::cout) const noexcept;
 
          /** The SP3 version (file format) is initially undefined, but
           * it will be assigned by reallyGetRecord() while reading,
@@ -199,8 +199,7 @@ namespace gpstk
          /// Writes the record formatted to the FFStream \a s.
          /// @throws StringException when a StringUtils function fails
       virtual void reallyPutRecord(FFStream& s) const
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
          /// This function retrieves the SP3 header from the given FFStream.
          /// If an error is encountered in the retrieval of the header, the
@@ -210,8 +209,7 @@ namespace gpstk
          ///  a read or formatting error occurs.  This also resets the
          ///  stream to its pre-read position.
       virtual void reallyGetRecord(FFStream& s)
-         throw(std::exception, FFStreamError,
-               StringUtils::StringException);
+         noexcept(false);
 
    }; // end class SP3Header
 

--- a/core/lib/FileHandling/SP3/SP3Stream.cpp
+++ b/core/lib/FileHandling/SP3/SP3Stream.cpp
@@ -69,7 +69,7 @@ namespace gpstk
 
 
    void SP3Stream ::
-   close(void) throw(Exception)
+   close(void) noexcept(false)
    {
       if (is_open())
       {

--- a/core/lib/FileHandling/SP3/SP3Stream.hpp
+++ b/core/lib/FileHandling/SP3/SP3Stream.hpp
@@ -73,7 +73,7 @@ namespace gpstk
       virtual ~SP3Stream();
 
          /// override close() to write EOF line
-      virtual void close(void) throw(Exception);
+      virtual void close(void) noexcept(false);
 
          /** override open() to reset the header
           * @param[in] filename the name of the ASCII SP3 format file

--- a/core/lib/GNSSCore/CGCS2000Ellipsoid.hpp
+++ b/core/lib/GNSSCore/CGCS2000Ellipsoid.hpp
@@ -59,57 +59,57 @@ namespace gpstk
    
          /// Defined in BDS ICD Section 3.2
          /// @return semi-major axis of Earth in meters.
-      virtual double a() const throw()
+      virtual double a() const noexcept
       { return 6378137.0; }
 
          /// Derived from BDS ICD Section 3.2
          /// @return semi-major axis of Earth in km.
-      virtual double a_km() const throw()
+      virtual double a_km() const noexcept
       { return a() / 1000.0; }
 
          /// Defined in BDS ICD Section 3.2
          /// @return flattening (ellipsoid parameter).
-      virtual double flattening() const throw()
+      virtual double flattening() const noexcept
       { return 0.335281068118e-2; }
 
          /// Unstated in BDS ICD. Derived as e = sqrt(2f - f*f)
          /// based on NGA TR8350.2 Section 7.4
          /// @return eccentricity (ellipsoid parameter).
-      virtual double eccentricity() const throw()
+      virtual double eccentricity() const noexcept
       { return 8.1819191042816e-2; }
 
          /// Unstated in BDS ICD. Derived as e^2 = 2f - f*f
          /// based on NGA TR8350.2 Section 7.4
          /// @return eccentricity squared (ellipsoid parameter).
-      virtual double eccSquared() const throw()
+      virtual double eccSquared() const noexcept
       { return 6.69438002290e-3; }
 
          /// Defined in BDS ICD Section 3.2
          /// @return angular velocity of Earth in radians/sec.
-      virtual double angVelocity() const throw()
+      virtual double angVelocity() const noexcept
       { return 7.292115e-5; }
 
          /// Defined in BDS ICD Section 3.2
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm() const throw()
+      virtual double gm() const noexcept
       { return 3986004.418e8; }
 
          /// @return geocentric gravitational constant in km**3 / s**2
-      virtual double gm_km() const throw()
+      virtual double gm_km() const noexcept
       { return 398600.4418; }
 
          /// Defined in BDS ICD Section 5.2.4.10
          /// @return Speed of light in m/s.
-      virtual double c() const throw()
+      virtual double c() const noexcept
       { return 299792458; }
 
          /// Derived from BDS ICD Section 5.2.4.10
          /// @return Speed of light in km/s
-      virtual double c_km() const throw()
+      virtual double c_km() const noexcept
       { return c()/1000.0; }
 
       /// Destructor.
-      virtual ~CGCS2000Ellipsoid() throw() {};
+      virtual ~CGCS2000Ellipsoid() noexcept {};
 
    }; // class CGCS2000Ellipsoid
 

--- a/core/lib/GNSSCore/EllipsoidModel.hpp
+++ b/core/lib/GNSSCore/EllipsoidModel.hpp
@@ -55,38 +55,38 @@ namespace gpstk
    {
    public:
          /// @return semi-major axis of Earth in meters.
-      virtual double a() const throw() = 0;
+      virtual double a() const noexcept = 0;
 
          /// @return semi-major axis of Earth in km.
-      virtual double a_km() const throw() = 0;
+      virtual double a_km() const noexcept = 0;
 
          /// @return flattening (ellipsoid parameter).
-      virtual double flattening() const throw() = 0;
+      virtual double flattening() const noexcept = 0;
 
          /// @return eccentricity (ellipsoid parameter).
-      virtual double eccentricity() const throw() = 0;
+      virtual double eccentricity() const noexcept = 0;
 
          /// @return eccentricity squared (ellipsoid parameter).
-      virtual double eccSquared() const throw()
+      virtual double eccSquared() const noexcept
       { return eccentricity() * eccentricity(); }
 
          /// @return angular velocity of Earth in radians/sec.
-      virtual double angVelocity() const throw() = 0;
+      virtual double angVelocity() const noexcept = 0;
 
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm() const throw() = 0;
+      virtual double gm() const noexcept = 0;
 
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm_km() const throw() = 0;
+      virtual double gm_km() const noexcept = 0;
 
          /// @return Speed of light in m/s.
-      virtual double c() const throw() = 0;
+      virtual double c() const noexcept = 0;
 
          /// @return Speed of light in km/s
-      virtual double c_km() const throw() = 0;
+      virtual double c_km() const noexcept = 0;
 
          /// Destructor.
-      virtual ~EllipsoidModel() throw() {};
+      virtual ~EllipsoidModel() noexcept {};
 
    }; // class EllipsoidModel
 

--- a/core/lib/GNSSCore/GCATTropModel.cpp
+++ b/core/lib/GNSSCore/GCATTropModel.cpp
@@ -97,7 +97,7 @@ namespace gpstk
        *                   degrees
        */
    double GCATTropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -119,7 +119,7 @@ namespace gpstk
        */
    double GCATTropModel::correction( const Position& RX,
                                      const Position& SV )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
 
       try
@@ -165,7 +165,7 @@ namespace gpstk
    double GCATTropModel::correction( const Xvt& RX,
                                      const Xvt& SV,
                                      const CommonTime& tt )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
 
       Position R(RX),S(SV);
@@ -178,7 +178,7 @@ namespace gpstk
        * troposphere.
        */
    double GCATTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -193,7 +193,7 @@ namespace gpstk
        *                   in degrees
        */
    double GCATTropModel::mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 

--- a/core/lib/GNSSCore/GCATTropModel.hpp
+++ b/core/lib/GNSSCore/GCATTropModel.hpp
@@ -110,7 +110,7 @@ namespace gpstk
           *                   degrees
           */
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -125,7 +125,7 @@ namespace gpstk
           */
       virtual double correction( const Position& RX,
                                  const Position& SV )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -143,7 +143,7 @@ namespace gpstk
       virtual double correction( const Position& RX,
                                  const Position& SV,
                                  const CommonTime& tt )
-         throw(InvalidTropModel)
+         noexcept(false)
       { return correction(RX, SV); };
 
 
@@ -164,21 +164,21 @@ namespace gpstk
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV,
                                  const CommonTime& tt )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the zenith delay for dry component of the
           *  troposphere.
           */
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the zenith delay for wet component of the
           *  troposphere.
           */
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel)
+         noexcept(false)
       { return 0.1; };
 
 
@@ -189,7 +189,7 @@ namespace gpstk
           *                   degrees
           */
       virtual double mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the mapping function for dry component
@@ -198,7 +198,7 @@ namespace gpstk
           *                   degrees
           */
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel)
+         noexcept(false)
       { return mapping_function(elevation); };
 
 
@@ -209,7 +209,7 @@ namespace gpstk
           *                   degrees
           */
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel)
+         noexcept(false)
       { return mapping_function(elevation); };
 
 
@@ -219,14 +219,14 @@ namespace gpstk
       virtual void setWeather( const double& T,
                                const double& P,
                                const double& H )
-         throw(InvalidParameter) {};
+         noexcept(false) {};
 
 
          /** In GCAT tropospheric model, this is a dummy method kept here just
           *  for consistency.
           */
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter) {};
+         noexcept(false) {};
 
 
          /** Define the receiver height; this is required before calling

--- a/core/lib/GNSSCore/GGHeightTropModel.cpp
+++ b/core/lib/GNSSCore/GGHeightTropModel.cpp
@@ -66,7 +66,7 @@ namespace gpstk
       // Creates a trop model from a weather observation
       // @param wx the weather to use for this correction.
    GGHeightTropModel::GGHeightTropModel(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       valid = validRxHeight = validHeights = false;
       setWeather(wx);
@@ -79,7 +79,7 @@ namespace gpstk
    GGHeightTropModel::GGHeightTropModel(const double& T,
                                         const double& P,
                                         const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       validRxHeight = validHeights = false;
       setWeather(T,P,H);
@@ -98,7 +98,7 @@ namespace gpstk
                                         const double hT,
                                         const double hP,
                                         const double hH)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       validRxHeight = false;
       setWeather(T,P,H);
@@ -107,7 +107,7 @@ namespace gpstk
 
       // re-define this to get the throws
    double GGHeightTropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -130,7 +130,7 @@ namespace gpstk
    double GGHeightTropModel::correction(const Position& RX,
                                         const Position& SV,
                                         const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -154,7 +154,7 @@ namespace gpstk
    double GGHeightTropModel::correction(const Xvt& RX,
                                         const Xvt& SV,
                                         const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       Position R(RX),S(SV);
       return GGHeightTropModel::correction(R,S,tt);
@@ -162,7 +162,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for dry component of the troposphere
    double GGHeightTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       double hrate=6.5e-3;
@@ -183,7 +183,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for wet component of the troposphere
    double GGHeightTropModel::wet_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -211,7 +211,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver,
       //                  in degrees
    double GGHeightTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -258,7 +258,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver,
       //                  in degrees
    double GGHeightTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       if(elevation < 0.0) return 0.0;
@@ -309,7 +309,7 @@ namespace gpstk
    void GGHeightTropModel::setWeather(const double& T,
                                       const double& P,
                                       const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       try
       {
@@ -328,7 +328,7 @@ namespace gpstk
       // Typically called just before correction().
       // @param wx the weather to use for this correction
    void GGHeightTropModel::setWeather(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/GNSSCore/GGHeightTropModel.hpp
+++ b/core/lib/GNSSCore/GGHeightTropModel.hpp
@@ -81,7 +81,7 @@ namespace gpstk
          /// Creates a trop model, with weather observation input
          /// @param wx the weather to use for this correction.
       GGHeightTropModel(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a tropospheric model from explicit weather data
          /// @param T temperature in degrees Celsius
@@ -90,7 +90,7 @@ namespace gpstk
       GGHeightTropModel(const double& T,
                         const double& P,
                         const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a valid model from explicit input.
          /// @param T temperature in degrees Celsius
@@ -105,7 +105,7 @@ namespace gpstk
                         const double hT,
                         const double hP,
                         const double hH)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Return the name of the model
       virtual std::string name(void)
@@ -114,7 +114,7 @@ namespace gpstk
          /// Compute and return the full tropospheric delay
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /**
           * Compute and return the full tropospheric delay, given the positions of
@@ -130,7 +130,7 @@ namespace gpstk
       virtual double correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /** \deprecated
           * Compute and return the full tropospheric delay, given the positions of
@@ -146,28 +146,28 @@ namespace gpstk
       virtual double correction(const Xvt& RX,
                                 const Xvt& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for dry component
          /// of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for wet component of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for dry component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for wet component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Re-define the weather data.
          /// Typically called initially, and whenever the weather changes.
@@ -177,13 +177,13 @@ namespace gpstk
       virtual void setWeather(const double& T,
                               const double& P,
                               const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
          /// @param wx the weather to use for this correction
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Re-define the heights at which the weather parameters apply.
          /// Typically called whenever setWeather is called.

--- a/core/lib/GNSSCore/GGTropModel.cpp
+++ b/core/lib/GNSSCore/GGTropModel.cpp
@@ -72,7 +72,7 @@ namespace gpstk
       // Creates a trop model from a weather observation
       // @param wx the weather to use for this correction.
    GGTropModel::GGTropModel(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       setWeather(wx);
       valid = true;
@@ -85,28 +85,28 @@ namespace gpstk
    GGTropModel::GGTropModel(const double& T,
                             const double& P,
                             const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       setWeather(T,P,H);
       valid = true;
    }
 
    double GGTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
       return (Cdrydelay * GGdryscale);
    }
 
    double GGTropModel::wet_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
       return (Cwetdelay * GGwetscale);
    }
 
    double GGTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -142,7 +142,7 @@ namespace gpstk
 
       // compute wet component of the mapping function
    double GGTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -178,7 +178,7 @@ namespace gpstk
    void GGTropModel::setWeather(const double& T,
                                 const double& P,
                                 const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       TropModel::setWeather(T,P,H);
       double th=300./temp;
@@ -197,7 +197,7 @@ namespace gpstk
       // Typically called just before correction().
       // @param wx the weather to use for this correction
    void GGTropModel::setWeather(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       TropModel::setWeather(wx);
    }

--- a/core/lib/GNSSCore/GGTropModel.hpp
+++ b/core/lib/GNSSCore/GGTropModel.hpp
@@ -58,7 +58,7 @@ namespace gpstk
          /// Creates a trop model, with weather observation input
          /// @param wx the weather to use for this correction.
       GGTropModel(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a tropospheric model from explicit weather data
          /// @param T temperature in degrees Celsius
@@ -67,7 +67,7 @@ namespace gpstk
       GGTropModel(const double& T,
                   const double& P,
                   const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Return the name of the model
       virtual std::string name(void)
@@ -76,24 +76,24 @@ namespace gpstk
          /// Compute and return the zenith delay for dry component
          /// of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for wet component
          /// of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for dry component
          /// of the troposphere
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for wet component
          /// of the troposphere
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called initially, and whenever the weather changes.
@@ -103,13 +103,13 @@ namespace gpstk
       virtual void setWeather(const double& T,
                               const double& P,
                               const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
          /// @param wx the weather to use for this correction
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
    private:
       double Cdrydelay;

--- a/core/lib/GNSSCore/GNSSconstants.hpp
+++ b/core/lib/GNSSCore/GNSSconstants.hpp
@@ -106,7 +106,7 @@ namespace gpstk
 
    inline
    short getLegacyFitInterval(const short iodc, const short fiti)
-      throw(gpstk::InvalidRequest )
+      noexcept(false)
    {
          /* check the IODC */
       if (iodc < 0 || iodc > 1023)
@@ -300,7 +300,7 @@ namespace gpstk
        * Calls for system GLO must include the frequency channel number N
        * (-7<=N<=7). */
    inline double getWavelength(const SatID& sat, const int& n, const int N=0)
-      throw()
+      noexcept
    {
       switch(sat.system)
       {
@@ -348,7 +348,7 @@ namespace gpstk
        * either of the input n's are not valid RINEX bands
        * (n=1,2,5,6,7,or 8) for the system. */
    inline double getBeta(const SatID& sat, const int& na, const int& nb)
-      throw()
+      noexcept
    {
       double wla = getWavelength(sat,na);
       double wlb = getWavelength(sat,nb);
@@ -362,7 +362,7 @@ namespace gpstk
        * @return 0 if either of the input n's are not valid RINEX
        *   bands (n=1,2,5,6,7,8) for the satellite system. */
    inline double getAlpha(const SatID& sat, const int& na, const int& nb)
-      throw()
+      noexcept
    {
       double beta(getBeta(sat,na,nb));
       if(beta == 0.0) return 0.0;

--- a/core/lib/GNSSCore/GPSEllipsoid.hpp
+++ b/core/lib/GNSSCore/GPSEllipsoid.hpp
@@ -67,27 +67,27 @@ namespace gpstk
    public:
          /// defined in ICD-GPS-200C, 20.3.3.4.3.3 and Table 20-IV
          /// @return angular velocity of Earth in radians/sec.
-      virtual double angVelocity() const throw()
+      virtual double angVelocity() const noexcept
       { return 7.2921151467e-5; }
 
          /// defined in ICD-GPS-200C, 20.3.3.4.3.3 and Table 20-IV
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm() const throw()
+      virtual double gm() const noexcept
       { return 3.986005e14; }
 
          /// derived from ICD-GPS-200C, 20.3.3.4.3.3 and Table 20-IV
          /// @return geocentric gravitational constant in km**3 / s**2
-      virtual double gm_km() const throw()
+      virtual double gm_km() const noexcept
       { return 3.9860034e5; }
 
          /// defined in ICD-GPS-200C, 20.3.4.3
          /// @return Speed of light in m/s.
-      virtual double c() const throw()
+      virtual double c() const noexcept
       { return C_MPS; }
 
          /// derived from ICD-GPS-200C, 20.3.4.3
          /// @return Speed of light in km/s
-      virtual double c_km() const throw()
+      virtual double c_km() const noexcept
       { return (C_MPS / 1000); }
 
    }; // class GPSEllipsoid

--- a/core/lib/GNSSCore/GalileoEllipsoid.hpp
+++ b/core/lib/GNSSCore/GalileoEllipsoid.hpp
@@ -57,56 +57,56 @@ namespace gpstk
          /// Unstated in Galileo OS SIS ICD.
          /// Used ITRF 2008 value
          /// @return semi-major axis of Earth in meters.
-      virtual double a() const throw()
+      virtual double a() const noexcept
       { return 6378137.0; }
 
          /// @return semi-major axis of Earth in km.
-      virtual double a_km() const throw()
+      virtual double a_km() const noexcept
       { return a() / 1000.0; }
 
          /// Unstated in Galileo OS SIS ICD.
          /// Used ITRF 2008 value
          /// @return flattening (ellipsoid parameter).
-      virtual double flattening() const throw()
+      virtual double flattening() const noexcept
       { return 0.335281068118e-2; }
 
          /// Unstated in Galileo OS SIS ICD. Derived as e = sqrt(2f - f*f)
          /// based on NGA TR8350.2 Section 7.4
          /// @return eccentricity (ellipsoid parameter).
-      virtual double eccentricity() const throw()
+      virtual double eccentricity() const noexcept
       { return 8.1819191042816e-2; }
 
          /// Unstated in Galileo OS SIS ICD. Derived as e^2 = 2f - f*f
          /// based on NGA TR8350.2 Section 7.4
          /// @return eccentricity squared (ellipsoid parameter).
-      virtual double eccSquared() const throw()
+      virtual double eccSquared() const noexcept
       { return 6.69438002290e-3; }
 
          /// Defined in Galileo OS SIS ICD Section 5.1.1
          /// @return angular velocity of Earth in radians/sec.
-      virtual double angVelocity() const throw()
+      virtual double angVelocity() const noexcept
       { return 7.2921151467e-5; }
 
          /// Defined in Galileo OS SIS ICD Section 5.1.1
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm() const throw()
+      virtual double gm() const noexcept
       { return 3986004.418e8; }
 
          /// @return geocentric gravitational constant in km**3 / s**2
-      virtual double gm_km() const throw()
+      virtual double gm_km() const noexcept
       { return 398600.4418; }
 
          /// Defined in Galileo OS SIS ICD Section 5.1.1
          /// @return Speed of light in m/s.
-      virtual double c() const throw()
+      virtual double c() const noexcept
       { return 299792458; }
 
          /// @return Speed of light in km/s
-      virtual double c_km() const throw()
+      virtual double c_km() const noexcept
       { return c()/1000.0; }
 
       /// Destructor.
-      virtual ~GalileoEllipsoid() throw() {};
+      virtual ~GalileoEllipsoid() noexcept {};
 
    }; // class GalileoEllipsoid
 

--- a/core/lib/GNSSCore/GlobalTropModel.cpp
+++ b/core/lib/GNSSCore/GlobalTropModel.cpp
@@ -287,7 +287,7 @@ namespace gpstk
    // methods.
    // @param elevation Elevation of satellite as seen at receiver, in degrees
    double GlobalTropModel::correction(double elevation) const       
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try { testValidity(); }
       catch(InvalidTropModel& e) { GPSTK_RETHROW(e); }
@@ -320,7 +320,7 @@ namespace gpstk
    // @param RX  Receiver position.
    // @param SV  Satellite position.
    double GlobalTropModel::correction(const Position& RX, const Position& SV)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try {
          double p;
@@ -350,7 +350,7 @@ namespace gpstk
    // the troposphere. Use the Saastamoinen value.
    // Ref. Davis etal 1985 and Leick, 3rd ed, pg 197.
    double GlobalTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try { testValidity(); } catch(InvalidTropModel& e) { GPSTK_RETHROW(e); }
       return SaasDryDelay(press,latitude,height);
@@ -360,7 +360,7 @@ namespace gpstk
    // Compute and return the zenith delay for wet component of
    // the troposphere. Ref. Leick, 3rd ed, pg 197, Leick, 4th ed, pg 482.
    double GlobalTropModel::wet_zenith_delay(void) const
-         throw(InvalidTropModel)
+         noexcept(false)
    {
       double T = temp + CELSIUS_TO_KELVIN;
       double pwv = 0.01 * humid * ::exp(-37.2465 + (0.213166-0.000256908*T)*T);
@@ -371,7 +371,7 @@ namespace gpstk
    // the troposphere.
    // @param elevation Elevation of satellite as seen at receiver, in degrees
    double GlobalTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try { testValidity(); } catch(InvalidTropModel& e) { GPSTK_RETHROW(e); }
       if(elevation < 3.0) { return 0.0; }
@@ -461,7 +461,7 @@ namespace gpstk
    //                  x^4 + x^3(2c) + x^2(2b+c^2) + x(2bc) + b^2
    //
    double GlobalTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try { testValidity(); }
       catch(InvalidTropModel& e) { GPSTK_RETHROW(e); }
@@ -505,7 +505,7 @@ namespace gpstk
    // Compute the pressure and temperature at height, and the undulation,
    // for the given position and time.
    void GlobalTropModel::getGPT(double& P, double& T, double& U)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try { testValidity(); }
       catch(InvalidTropModel& e) { GPSTK_RETHROW(e); }
@@ -665,7 +665,7 @@ namespace gpstk
    }
 
    // Utility to test valid flags
-   void GlobalTropModel::testValidity(void) const throw(InvalidTropModel)
+   void GlobalTropModel::testValidity(void) const noexcept(false)
    {
       if(!valid) {
          if(!validLat)

--- a/core/lib/GNSSCore/GlobalTropModel.hpp
+++ b/core/lib/GNSSCore/GlobalTropModel.hpp
@@ -144,7 +144,7 @@ namespace gpstk
       /// @param elevation Elevation of satellite as seen at receiver,
       ///                  in degrees.
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// Compute and return the full tropospheric delay, given the
       ///  positions of receiver and satellite.
@@ -160,7 +160,7 @@ namespace gpstk
       /// @param RX  Receiver position.
       /// @param SV  Satellite position.
       virtual double correction(const Position& RX, const Position& SV)
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// Compute and return the full tropospheric delay, given the
       ///  positions of receiver and satellite and the time tag.
@@ -176,7 +176,7 @@ namespace gpstk
       virtual double correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-        throw(InvalidTropModel)
+        noexcept(false)
       {
          setTime(tt);
          return correction(RX,SV);
@@ -186,18 +186,18 @@ namespace gpstk
       /// the troposphere. Use the Saastamoinen value.
       /// Ref. Davis etal 1985 and Leick, 3rd ed, pg 197.
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// Compute and return the zenith delay for wet component of
       /// the troposphere. Ref. Leick, 3rd ed, pg 197.
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// Compute and return the mapping function for hydrostatic (dry)
       /// component of the troposphere.
       /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// Compute and return the mapping function for wet component of
       /// the troposphere, as well as the derivative of the mapping function.
@@ -206,13 +206,13 @@ namespace gpstk
       /// @param doderiv bool if false, do NOT compute the derivative (default true);
       //double wet_mapping_function_with_derivative(double elevation,
       //                                       double& deriv, bool doderiv=true) const
-      //   throw(InvalidTropModel);
+      //   noexcept(false);
 
       /// Compute and return the mapping function for wet component of
       /// the troposphere.
       /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// Compute the pressure and temperature at height, and the undulation,
       /// for the given position and time.
@@ -221,21 +221,21 @@ namespace gpstk
       /// @param U output undulation
       /// @throw if the height is larger than 44247 meters, which is beyond the model
       void getGPT(double& P, double& T, double& U)
-         throw(InvalidTropModel);
+         noexcept(false);
 
       /// GlobalTropModel does not accept weather input, except humid
       virtual void setWeather(const double& T, const double& P, const double& H)
-         throw(InvalidParameter) { setHumidity(H); }
+         noexcept(false) { setHumidity(H); }
 
       /// GlobalTropModel does not accept weather input, except humid
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter) { setHumidity(wx.humidity); }
+         noexcept(false) { setHumidity(wx.humidity); }
 
       /// GlobalTropModel does not accept weather input, except humid;
       /// thus the setWeather() routines are dummies; this sets the relative humidity.
       /// NB. humidity enters only in the wet zenith delay, which is not part of GTM.
       /// @param rh double relative humidity in percent (0 <= rh <= 100)
-      void setHumidity(const double& rh) throw(InvalidParameter)
+      void setHumidity(const double& rh) noexcept(false)
       {
          if(rh < 0.0 || rh > 100.)
             GPSTK_THROW(InvalidParameter("Invalid humidity (%)"));
@@ -309,11 +309,11 @@ namespace gpstk
       void updateGTMCoeff(void);
 
       /// Utility to test valid flags
-      void testValidity(void) const throw(InvalidTropModel);
+      void testValidity(void) const noexcept(false);
 
       /// Utility to set valid based on the other flags,
       /// and update coefficients and press, temp as needed
-      void setValid(void) throw(InvalidTropModel)
+      void setValid(void) noexcept(false)
       {
          try{
             valid = validHeight && validLat && validLon && validDay;

--- a/core/lib/GNSSCore/IonoModel.cpp
+++ b/core/lib/GNSSCore/IonoModel.cpp
@@ -47,13 +47,13 @@
 
 namespace gpstk
 {
-   IonoModel::IonoModel(const double a[4], const double b[4]) throw()
+   IonoModel::IonoModel(const double a[4], const double b[4]) noexcept
    {
         setModel(a, b);
    }
 
    IonoModel::IonoModel(const EngAlmanac& engalm)
-      throw()
+      noexcept
    {
       try
       {
@@ -67,7 +67,7 @@ namespace gpstk
    }
 
 
-   void IonoModel::setModel(const double a[4], const double b[4]) throw()
+   void IonoModel::setModel(const double a[4], const double b[4]) noexcept
    {
       for (int n = 0; n < 4; n++)
       {
@@ -83,7 +83,7 @@ namespace gpstk
                                    double svel,
                                    double svaz,
                                    Frequency freq) const
-      throw(IonoModel::InvalidIonoModel)
+      noexcept(false)
    {
 
       if (!valid)
@@ -152,7 +152,7 @@ namespace gpstk
    }
 
    bool IonoModel::operator==(const IonoModel& right) const
-      throw()
+      noexcept
    {
       for (int n = 0; n < 4; n++)
       {
@@ -163,7 +163,7 @@ namespace gpstk
    }
 
    bool IonoModel::operator!=(const IonoModel&right) const
-      throw()
+      noexcept
    {
       return !(operator==(right));
    }

--- a/core/lib/GNSSCore/IonoModel.hpp
+++ b/core/lib/GNSSCore/IonoModel.hpp
@@ -83,10 +83,10 @@ namespace gpstk
       };
       
          /// default constructor, creates an invalid model
-      IonoModel() throw() : valid(false) {}
+      IonoModel() noexcept : valid(false) {}
       
          /// destructor
-      virtual ~IonoModel() throw() {}
+      virtual ~IonoModel() noexcept {}
       
          /**
           * constructor.
@@ -95,27 +95,27 @@ namespace gpstk
           * \param a an array containing the four alpha terms
           * \param b an array containing the four beta terms
           */
-      IonoModel(const double a[4], const double b[4]) throw();
+      IonoModel(const double a[4], const double b[4]) noexcept;
       
          /**
           * EngAlmanac constructor.
           * Creates a valid model from and EngAlmanac object
           * \param engalm an EngAlmanac object
           */
-      IonoModel(const EngAlmanac& engalm) throw();
+      IonoModel(const EngAlmanac& engalm) noexcept;
       
          /** Method to feed the model with satellite transmitted alpha
           * and beta parameters provided from almanac.
           * \param a an array containing the four alpha terms
           * \param b an array containing the four beta terms
           */
-      void setModel(const double a[4], const double b[4]) throw();
+      void setModel(const double a[4], const double b[4]) noexcept;
       
          /**
           * returns the validity of the model.
           * \return model validity
           */
-      bool isValid() const throw() { return valid; }
+      bool isValid() const noexcept { return valid; }
       
          /**
           * get the ionospheric correction value.
@@ -131,13 +131,13 @@ namespace gpstk
                            double svel,
                            double svaz,
                            Frequency freq = L1) const
-         throw(InvalidIonoModel);
+         noexcept(false);
 
          /// equality operator
-      bool operator==(const IonoModel& right) const throw();
+      bool operator==(const IonoModel& right) const noexcept;
 
          /// inequality operator
-      bool operator!=(const IonoModel& right) const throw();     
+      bool operator!=(const IonoModel& right) const noexcept;     
 
    private:
 

--- a/core/lib/GNSSCore/IonoModelStore.cpp
+++ b/core/lib/GNSSCore/IonoModelStore.cpp
@@ -60,7 +60,7 @@ namespace gpstk
                                         double svel,
                                         double svaz,
                                         IonoModel::Frequency freq) const
-      throw(IonoModelStore::NoIonoModelFound)
+      noexcept(false)
    {
 
       IonoModelMap::const_iterator i = ims.upper_bound(time);
@@ -85,7 +85,7 @@ namespace gpstk
        * \return true if the model was added, false otherwise
        */
    bool IonoModelStore::addIonoModel(const CommonTime& mt, const IonoModel& im)
-      throw()
+      noexcept
    {
 
       if (!im.isValid())

--- a/core/lib/GNSSCore/IonoModelStore.hpp
+++ b/core/lib/GNSSCore/IonoModelStore.hpp
@@ -91,7 +91,7 @@ namespace gpstk
                            double svel,
                            double svaz,
                            IonoModel::Frequency freq = IonoModel::L1) const
-         throw(NoIonoModelFound);
+         noexcept(false);
 
 
          /** Add an IonoModel to this collection
@@ -102,7 +102,7 @@ namespace gpstk
           */
       bool addIonoModel( const CommonTime& mt,
                          const IonoModel& im )
-         throw();
+         noexcept;
 
          /** Edit the dataset, removing data outside the indicated time interval
           *

--- a/core/lib/GNSSCore/MOPSTropModel.cpp
+++ b/core/lib/GNSSCore/MOPSTropModel.cpp
@@ -138,7 +138,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver, in
       // degrees
    double MOPSTropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -165,7 +165,7 @@ namespace gpstk
       // @param SV  Satellite position
    double MOPSTropModel::correction( const Position& RX,
                                      const Position& SV )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       try
       {
@@ -206,7 +206,7 @@ namespace gpstk
    double MOPSTropModel::correction( const Position& RX,
                                      const Position& SV,
                                      const CommonTime& tt )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(tt);
 
@@ -226,7 +226,7 @@ namespace gpstk
    double MOPSTropModel::correction( const Position& RX,
                                      const Position& SV,
                                      const int& doy )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(doy);
 
@@ -244,7 +244,7 @@ namespace gpstk
       // This function is deprecated; use the Position version
    double MOPSTropModel::correction( const Xvt& RX,
                                      const Xvt& SV )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       Position R(RX),S(SV);
 
@@ -265,7 +265,7 @@ namespace gpstk
    double MOPSTropModel::correction( const Xvt& RX,
                                      const Xvt& SV,
                                      const CommonTime& tt )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(tt);
       Position R(RX),S(SV);
@@ -288,7 +288,7 @@ namespace gpstk
    double MOPSTropModel::correction( const Xvt& RX,
                                      const Xvt& SV,
                                      const int& doy )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(doy);
       Position R(RX),S(SV);
@@ -300,7 +300,7 @@ namespace gpstk
       // Compute and return the zenith delay for the dry component of the
       // troposphere
    double MOPSTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -327,7 +327,7 @@ namespace gpstk
       // Compute and return the zenith delay for the wet component of the
       // troposphere
    double MOPSTropModel::wet_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -356,7 +356,7 @@ namespace gpstk
       // latitude and day of year (DOY). It is called automatically when
       // setting those parameters.
    void MOPSTropModel::setWeather()
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       if(!validLat)
       {
@@ -498,7 +498,7 @@ namespace gpstk
       // @param elevation  Elevation of satellite as seen at receiver,
       //                   in degrees
    double MOPSTropModel::MOPSsigma2(double elevation)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       double map_f;
 
@@ -522,7 +522,7 @@ namespace gpstk
 
       // The MOPS tropospheric model needs to compute several extra parameters
    void MOPSTropModel::prepareParameters(void)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 

--- a/core/lib/GNSSCore/MOPSTropModel.hpp
+++ b/core/lib/GNSSCore/MOPSTropModel.hpp
@@ -127,7 +127,7 @@ namespace gpstk
           *                    degrees.
           */
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -144,7 +144,7 @@ namespace gpstk
           */
       virtual double correction( const Position& RX,
                                  const Position& SV )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -162,7 +162,7 @@ namespace gpstk
       virtual double correction( const Position& RX,
                                  const Position& SV,
                                  const CommonTime& tt )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -180,7 +180,7 @@ namespace gpstk
       virtual double correction( const Position& RX,
                                  const Position& SV,
                                  const int& doy )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** \deprecated
@@ -195,7 +195,7 @@ namespace gpstk
           */
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** \deprecated
@@ -215,7 +215,7 @@ namespace gpstk
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV,
                                  const CommonTime& tt )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** \deprecated
@@ -235,19 +235,19 @@ namespace gpstk
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV,
                                  const int& doy )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// Compute and return the zenith delay for dry component of the
          /// troposphere.
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// Compute and return the zenith delay for wet component of the
          /// troposphere.
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** This method configure the model to estimate the weather using
@@ -255,7 +255,7 @@ namespace gpstk
           *  when setting those parameters.
           */
       void setWeather()
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// In MOPS tropospheric model, this is a dummy method kept here just
@@ -263,13 +263,13 @@ namespace gpstk
       virtual void setWeather( const double& T,
                                const double& P,
                                const double& H )
-         throw(InvalidParameter) {};
+         noexcept(false) {};
 
 
          /// In MOPS tropospheric model, this is a dummy method kept here just
          /// for consistency.
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter) {};
+         noexcept(false) {};
 
 
          /** Define the receiver height; this is required before calling
@@ -320,7 +320,7 @@ namespace gpstk
           *                   in degrees
           */
       double MOPSsigma2(double elevation)
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
    private:
@@ -339,7 +339,7 @@ namespace gpstk
 
          // The MOPS tropospheric model needs to compute several extra
          // parameters
-      virtual void prepareParameters(void) throw(InvalidTropModel);
+      virtual void prepareParameters(void) noexcept(false);
 
 
          // The MOPS tropospheric model uses several predefined data tables

--- a/core/lib/GNSSCore/NBTropModel.cpp
+++ b/core/lib/GNSSCore/NBTropModel.cpp
@@ -165,7 +165,7 @@ namespace gpstk
       // @param day Day of year.
    NBTropModel::NBTropModel(const double& lat,
                             const int& day)
-      throw(InvalidParameter):
+      noexcept(false):
       validWeather(false), validRxLatitude(false), validDOY(false),validRxHeight(false)
    {
       setReceiverLatitude(lat);
@@ -180,7 +180,7 @@ namespace gpstk
    NBTropModel::NBTropModel(const double& lat,
                             const int& day,
                             const WxObservation& wx)
-      throw(InvalidParameter):
+      noexcept(false):
       validWeather(false), validRxLatitude(false), validDOY(false),validRxHeight(false)
    {
       setReceiverLatitude(lat);
@@ -199,7 +199,7 @@ namespace gpstk
                             const double& T,
                             const double& P,
                             const double& H)
-      throw(InvalidParameter):
+      noexcept(false):
       validWeather(false), validRxLatitude(false), validDOY(false),validRxHeight(false)
    {
       setReceiverLatitude(lat);
@@ -215,7 +215,7 @@ namespace gpstk
    NBTropModel::NBTropModel(const double& ht,
                             const double& lat,
                             const int& day)
-      throw(InvalidParameter):
+      noexcept(false):
       validWeather(false), validRxLatitude(false), validDOY(false),validRxHeight(false)
    {
       setReceiverHeight(ht);
@@ -226,7 +226,7 @@ namespace gpstk
 
       // re-define this to get the throws
    double NBTropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -248,7 +248,7 @@ namespace gpstk
    double NBTropModel::correction(const Position& RX,
                                   const Position& SV,
                                   const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -275,7 +275,7 @@ namespace gpstk
    double NBTropModel::correction(const Xvt& RX,
                                   const Xvt& SV,
                                   const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       Position R(RX),S(SV);
       return NBTropModel::correction(R,S,tt);
@@ -283,7 +283,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for dry component of the troposphere
    double NBTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -303,7 +303,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for wet component of the troposphere
    double NBTropModel::wet_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -327,7 +327,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver,
       //                  in degrees
    double NBTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -356,7 +356,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver,
       //                  in degrees
    double NBTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       
@@ -380,7 +380,7 @@ namespace gpstk
    void NBTropModel::setWeather(const double& T,
                                 const double& P,
                                 const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       interpolateWeather=false;
       TropModel::setWeather(T,P,H);
@@ -396,7 +396,7 @@ namespace gpstk
       // Typically called just before correction().
       // @param wx the weather to use for this correction
    void NBTropModel::setWeather(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       interpolateWeather = false;
       try
@@ -418,7 +418,7 @@ namespace gpstk
       // configure the model to estimate the weather from the internal model,
       // using lat and doy
    void NBTropModel::setWeather()
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       interpolateWeather = true;
 

--- a/core/lib/GNSSCore/NBTropModel.hpp
+++ b/core/lib/GNSSCore/NBTropModel.hpp
@@ -89,7 +89,7 @@ namespace gpstk
          /// @param day Day of year.
       NBTropModel(const double& lat,
                   const int& day)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a trop model with weather.
          /// @param lat Latitude of the receiver in degrees.
@@ -98,7 +98,7 @@ namespace gpstk
       NBTropModel(const double& lat,
                   const int& day,
                   const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a tropospheric model from explicit weather data
          /// @param lat Latitude of the receiver in degrees.
@@ -111,7 +111,7 @@ namespace gpstk
                   const double& T,
                   const double& P,
                   const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a valid model from explicit input
          /// (weather will be estimated internally by this model).
@@ -121,7 +121,7 @@ namespace gpstk
       NBTropModel(const double& ht,
                   const double& lat,
                   const int& day)
-         throw(InvalidParameter);
+         noexcept(false);
 
       /// Return the name of the model
       virtual std::string name(void)
@@ -130,7 +130,7 @@ namespace gpstk
          /// Compute and return the full tropospheric delay
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /**
           * Compute and return the full tropospheric delay, given the positions of
@@ -146,7 +146,7 @@ namespace gpstk
       virtual double correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /** \deprecated
           * Compute and return the full tropospheric delay, given the positions of
@@ -162,35 +162,35 @@ namespace gpstk
       virtual double correction(const Xvt& RX,
                                 const Xvt& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for dry component
          /// of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for wet component
          /// of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for dry component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for wet component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
          /// @param wx the weather to use for this correction
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Define the weather data; typically called just before correction().
          /// @param T temperature in degrees Celsius
@@ -199,11 +199,11 @@ namespace gpstk
       virtual void setWeather(const double& T,
                               const double& P,
                               const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// configure the model to estimate the weather using lat and doy
       void setWeather()
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Define the receiver height; this required before calling
          /// correction() or any of the zenith_delay or mapping_function routines.

--- a/core/lib/GNSSCore/NeillTropModel.cpp
+++ b/core/lib/GNSSCore/NeillTropModel.cpp
@@ -142,7 +142,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver,
       // in degrees
    double NeillTropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -180,7 +180,7 @@ namespace gpstk
        */
    double NeillTropModel::correction( const Position& RX,
                                       const Position& SV )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
 
       try
@@ -228,7 +228,7 @@ namespace gpstk
    double NeillTropModel::correction( const Position& RX,
                                       const Position& SV,
                                       const CommonTime& tt )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(tt);
 
@@ -251,7 +251,7 @@ namespace gpstk
    double NeillTropModel::correction( const Position& RX,
                                       const Position& SV,
                                       const int& doy )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(doy);
 
@@ -270,7 +270,7 @@ namespace gpstk
       // This function is deprecated; use the Position version
    double NeillTropModel::correction( const Xvt& RX,
                                       const Xvt& SV )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       Position R(RX),S(SV);
       return NeillTropModel::correction(R,S);
@@ -291,7 +291,7 @@ namespace gpstk
    double NeillTropModel::correction( const Xvt& RX,
                                       const Xvt& SV,
                                       const CommonTime& tt )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(tt);
       Position R(RX),S(SV);
@@ -314,7 +314,7 @@ namespace gpstk
    double NeillTropModel::correction( const Xvt& RX,
                                       const Xvt& SV,
                                       const int& doy )
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       setDayOfYear(doy);
       Position R(RX),S(SV);
@@ -326,7 +326,7 @@ namespace gpstk
       // Compute and return the zenith delay for the dry component of
       // the troposphere.
    double NeillTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -347,7 +347,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver, in
       //                  degrees
    double NeillTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -413,7 +413,7 @@ namespace gpstk
       // @param elevation Elevation of satellite as seen at receiver,
       //                  in degrees.
    double NeillTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -457,7 +457,7 @@ namespace gpstk
       // latitude and day of year (DOY). It is called automatically when
       // setting those parameters.
    void NeillTropModel::setWeather()
-      throw(InvalidTropModel)
+      noexcept(false)
    {
 
       if(!validLat)

--- a/core/lib/GNSSCore/NeillTropModel.hpp
+++ b/core/lib/GNSSCore/NeillTropModel.hpp
@@ -134,7 +134,7 @@ namespace gpstk
          /// @param elevation Elevation of satellite as seen at receiver,
          ///                  in degrees.
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -153,7 +153,7 @@ namespace gpstk
           */
       virtual double correction( const Position& RX,
                                  const Position& SV )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -171,7 +171,7 @@ namespace gpstk
       virtual double correction( const Position& RX,
                                  const Position& SV,
                                  const CommonTime& tt )
-        throw(InvalidTropModel);
+        noexcept(false);
 
 
          /** Compute and return the full tropospheric delay, given the
@@ -189,7 +189,7 @@ namespace gpstk
       virtual double correction( const Position& RX,
                                  const Position& SV,
                                  const int& doy )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** \deprecated
@@ -204,7 +204,7 @@ namespace gpstk
           */
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV  )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** \deprecated
@@ -224,7 +224,7 @@ namespace gpstk
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV,
                                  const CommonTime& tt )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /** \deprecated
@@ -244,19 +244,19 @@ namespace gpstk
       virtual double correction( const Xvt& RX,
                                  const Xvt& SV,
                                  const int& doy )
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// Compute and return the zenith delay for dry component of
          /// the troposphere.
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// Compute and return the zenith delay for wet component of
          /// the troposphere.
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel)
+         noexcept(false)
       { return 0.1; };           // Returns a nominal value
 
 
@@ -266,7 +266,7 @@ namespace gpstk
          /// @param elevation Elevation of satellite as seen at receiver, in
          ///                  degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// Compute and return the mapping function for wet component of
@@ -275,14 +275,14 @@ namespace gpstk
          /// @param elevation Elevation of satellite as seen at
          ///                  receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// This method configure the model to estimate the weather using
          /// height, latitude and day of year (DOY). It is called
          /// automatically when setting those parameters.
       void setWeather()
-         throw(InvalidTropModel);
+         noexcept(false);
 
 
          /// In Neill tropospheric model, this is a dummy method kept here
@@ -290,13 +290,13 @@ namespace gpstk
       virtual void setWeather( const double& T,
                                const double& P,
                                const double& H )
-         throw(InvalidParameter) {};
+         noexcept(false) {};
 
 
          /// In Neill tropospheric model, this is a dummy method kept here
          /// just for consistency
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter) {};
+         noexcept(false) {};
 
 
          /// Define the receiver height; this is required before calling

--- a/core/lib/GNSSCore/ObsID.cpp
+++ b/core/lib/GNSSCore/ObsID.cpp
@@ -70,7 +70,7 @@ namespace gpstk
    ObsIDInitializer singleton;
 
    // Construct this object from the string specifier
-   ObsID::ObsID(const std::string& strID) throw(InvalidParameter)
+   ObsID::ObsID(const std::string& strID) noexcept(false)
    {
       int i = strID.length() - 3;
       if ( i < 0 || i > 1)
@@ -315,7 +315,7 @@ namespace gpstk
    // Rinex 3 identifier is the same as for the ObsID constructor. 
    // If there are spaces in the provided identifier, they are ignored
    ObsID ObsID::newID(const std::string& strID, const std::string& desc)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       if (char2ot.count(strID[0]) && 
           char2cb.count(strID[1]) && 

--- a/core/lib/GNSSCore/ObsID.hpp
+++ b/core/lib/GNSSCore/ObsID.hpp
@@ -255,10 +255,10 @@ namespace gpstk
           * isn't currently defined, a new one is silently
           * automatically created with a blank description for the new
           * characters. */
-      explicit ObsID(const std::string& id) throw(InvalidParameter);
+      explicit ObsID(const std::string& id) noexcept(false);
 
          /// Constructor from c-style string; see c'tor from a string.
-      explicit ObsID(const char* id) throw(InvalidParameter)
+      explicit ObsID(const char* id) noexcept(false)
       { *this=ObsID(std::string(id));}
 
          /// Equality requires all fields to be the same
@@ -301,7 +301,7 @@ namespace gpstk
           * ObsID can then be examined for the assigned values. */
       static ObsID newID(const std::string& id,
                          const std::string& desc="")
-         throw(InvalidParameter);
+         noexcept(false);
 
          // Note that these are the only data members of objects of this class.
       ObservationType  type;

--- a/core/lib/GNSSCore/PZ90Ellipsoid.hpp
+++ b/core/lib/GNSSCore/PZ90Ellipsoid.hpp
@@ -55,19 +55,19 @@ namespace gpstk
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return semi-major axis of Earth in meters.
-      virtual double a() const throw()
+      virtual double a() const noexcept
       { return 6378136.0; }
 		 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return semi-major axis of Earth in km.
-      virtual double a_km() const throw()
+      virtual double a_km() const noexcept
       { return a() / 1000.0; }
 
          /**
           * Defined in table 3.2 of the GLONASS ICD-2008 (v5.1)
           * @return inverse o flattening (ellipsoid parameter).
           */
-      virtual double flatteningInverse() const throw()
+      virtual double flatteningInverse() const noexcept
       { return 298.25784; }
 
          /**
@@ -75,7 +75,7 @@ namespace gpstk
           * of the GLONASS ICD-2008 (v5.1)
           * @return flattening (ellipsoid parameter).
           */
-      virtual double flattening() const throw()
+      virtual double flattening() const noexcept
       { return 3.35280373518e-3; }
      
          // The eccentricity and eccSquared values were computed from the
@@ -83,45 +83,45 @@ namespace gpstk
          // ecc2 = 1 - (1 - f)^2 = f*(2.0 - f)
          // ecc = sqrt(ecc2)
          /// @return eccentricity (ellipsoid parameter).
-      virtual double eccentricity() const throw()
+      virtual double eccentricity() const noexcept
       { return 8.1819106432923e-2; }
 
          /// @return eccentricity squared (ellipsoid parameter).
-      virtual double eccSquared() const throw()
+      virtual double eccSquared() const noexcept
       { return 6.69436617748e-3; }
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return angular velocity of Earth in radians/sec.
-      virtual double angVelocity() const throw()
+      virtual double angVelocity() const noexcept
       { return 7.292115e-5; }
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm() const throw()
+      virtual double gm() const noexcept
       { return 398600.4418e9; }
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return geocentric gravitational constant in km**3 / s**2
-      virtual double gm_km() const throw()
+      virtual double gm_km() const noexcept
       { return 398600.4418; }
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return Speed of light in m/s.
-      virtual double c() const throw()
+      virtual double c() const noexcept
       { return 299792458; }
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return Speed of light in km/s
-      virtual double c_km() const throw()
+      virtual double c_km() const noexcept
       { return c()/1000.0; }
 
          ///Defined in table 3.2 of ICD-2008 (v5.1)
          /// @return Returns second zonal harmonic of the geopotential.
-      virtual double j20() const throw()
+      virtual double j20() const noexcept
       { return (-1.08262575e-3); }
 
          /// Destructor.
-      virtual ~PZ90Ellipsoid() throw() {};
+      virtual ~PZ90Ellipsoid() noexcept {};
 
    }; // End of class 'PZ90Ellipsoid'
 

--- a/core/lib/GNSSCore/Position.cpp
+++ b/core/lib/GNSSCore/Position.cpp
@@ -66,7 +66,7 @@ namespace gpstk
 
       // return string giving name of coordinate system
    string Position::getSystemName()
-      throw()
+      noexcept
    { return SystemNames[system]; }
 
    // ----------- Part  2: tolerance -----------------------------------------
@@ -85,7 +85,7 @@ namespace gpstk
       // for some easy to use tolerance values.
       // @param tol Tolerance in meters to be used by comparison operators.
    Position& Position::setTolerance(const double tol)
-      throw()
+      noexcept
    {
       tolerance = tol;
       return *this;
@@ -95,7 +95,7 @@ namespace gpstk
    //
       // Default constructor.
    Position::Position()
-      throw()
+      noexcept
    {
       WGS84Ellipsoid WGS84;
       initialize(0.0,0.0,0.0,Unknown,&WGS84);
@@ -107,7 +107,7 @@ namespace gpstk
                       Position::CoordinateSystem s,
                       EllipsoidModel *ell,
                       ReferenceFrame frame)
-      throw(GeometryException)
+      noexcept(false)
    {
       try {
          initialize(a,b,c,s,ell,frame);
@@ -121,7 +121,7 @@ namespace gpstk
                       CoordinateSystem s,
                       EllipsoidModel *ell,
                       ReferenceFrame frame)
-      throw(GeometryException)
+      noexcept(false)
    {
       double a=ABC[0];
       double b=ABC[1];
@@ -138,7 +138,7 @@ namespace gpstk
                       CoordinateSystem s,
                       EllipsoidModel *ell,
                       ReferenceFrame frame)
-      throw(GeometryException)
+      noexcept(false)
    {
       double a=ABC[0];
       double b=ABC[1];
@@ -152,7 +152,7 @@ namespace gpstk
    }
 
    Position::Position(const Xvt& xvt)
-      throw()
+      noexcept
    {
       double a=xvt.x[0];
       double b=xvt.x[1];
@@ -163,7 +163,7 @@ namespace gpstk
    // ----------- Part  4: member functions: arithmetic ----------------------
    //
    Position& Position::operator-=(const Position& right)
-      throw()
+      noexcept
    {
       Position r(right);
       CoordinateSystem savesys=system;    // save the original system
@@ -180,7 +180,7 @@ namespace gpstk
    }
 
    Position& Position::operator+=(const Position& right)
-      throw()
+      noexcept
    {
       Position r(right);
       CoordinateSystem savesys=system;    // save the original system
@@ -198,7 +198,7 @@ namespace gpstk
 
    Position operator-(const Position& left,
                             const Position& right)
-      throw()
+      noexcept
    {
       Position l(left),r(right);
          // convert both to Cartesian
@@ -212,7 +212,7 @@ namespace gpstk
 
    Position operator+(const Position& left,
                             const Position& right)
-      throw()
+      noexcept
    {
       Position l(left),r(right);
          // convert both to Cartesian
@@ -228,7 +228,7 @@ namespace gpstk
    //
       // Equality operator. Returns false if ell values differ.
    bool Position::operator==(const Position &right) const
-      throw()
+      noexcept
    {
       if(AEarth != right.AEarth || eccSquared != right.eccSquared)
          return false;
@@ -242,7 +242,7 @@ namespace gpstk
 
       // Inequality operator. Returns true if ell values differ.
    bool Position::operator!=(const Position &right) const
-      throw()
+      noexcept
    {
       return !(operator==(right));
    }
@@ -254,7 +254,7 @@ namespace gpstk
       // @param sys coordinate system into which *this is to be transformed.
       // @return *this
    Position Position::transformTo(CoordinateSystem sys)
-      throw()
+      noexcept
    {
       if(sys == Unknown || sys == system) return *this;
 
@@ -353,14 +353,14 @@ namespace gpstk
    //
    
    const ReferenceFrame& Position::getReferenceFrame() const
-      throw()
+      noexcept
    {   
       return refFrame;
    }
    
       // Get X coordinate (meters)
    double Position::X() const
-      throw()
+      noexcept
    {
       if(system == Cartesian)
          return theArray[0];
@@ -371,7 +371,7 @@ namespace gpstk
 
       // Get Y coordinate (meters)
    double Position::Y() const
-      throw()
+      noexcept
    {
       if(system == Cartesian)
          return theArray[1];
@@ -382,7 +382,7 @@ namespace gpstk
 
       // Get Z coordinate (meters)
    double Position::Z() const
-      throw()
+      noexcept
    {
       if(system == Cartesian)
          return theArray[2];
@@ -393,7 +393,7 @@ namespace gpstk
 
       // Get geodetic latitude (degrees North).
    double Position::geodeticLatitude() const
-      throw()
+      noexcept
    {
       if(system == Geodetic)
          return theArray[0];
@@ -405,7 +405,7 @@ namespace gpstk
       // Get geocentric latitude (degrees North),
       // equal to 90 degress - theta in regular spherical coordinates.
    double Position::geocentricLatitude() const
-      throw()
+      noexcept
    {
       if(system == Geocentric)
          return theArray[0];
@@ -416,7 +416,7 @@ namespace gpstk
 
       // Get spherical coordinate theta in degrees
    double Position::theta() const
-      throw()
+      noexcept
    {
       if(system == Spherical)
          return theArray[0];
@@ -427,7 +427,7 @@ namespace gpstk
 
       // Get spherical coordinate phi in degrees
    double Position::phi() const
-      throw()
+      noexcept
    {
       if(system == Spherical)
          return theArray[1];
@@ -439,7 +439,7 @@ namespace gpstk
       // Get longitude (degrees East),
       // equal to phi in regular spherical coordinates.
    double Position::longitude() const
-      throw()
+      noexcept
    {
       if(system != Cartesian)
          return theArray[1];
@@ -451,7 +451,7 @@ namespace gpstk
       // Get radius or distance from the center of Earth (meters),
       // Same as radius in spherical coordinates.
    double Position::radius() const
-      throw()
+      noexcept
    {
       if(system == Spherical || system == Geocentric)
          return theArray[2];
@@ -462,7 +462,7 @@ namespace gpstk
 
       // Get height above ellipsoid (meters) (Geodetic).
    double Position::height() const
-      throw()
+      noexcept
    {
       if(system == Geodetic)
          return theArray[2];
@@ -474,7 +474,7 @@ namespace gpstk
    // ----------- Part  8: member functions: set -----------------------------
    //
    void Position::setReferenceFrame(const ReferenceFrame& frame)
-      throw()
+      noexcept
    {
       refFrame = frame;
    }
@@ -485,7 +485,7 @@ namespace gpstk
       * @throw      GeometryException if input is NULL.
       */
    void Position::setEllipsoidModel(const EllipsoidModel *ell)
-      throw(GeometryException)
+      noexcept(false)
    {
       if(!ell)
       {
@@ -506,7 +506,7 @@ namespace gpstk
                                    const double lon,
                                    const double ht,
                                    const EllipsoidModel *ell)
-      throw(GeometryException)
+      noexcept(false)
    {
       if(lat > 90 || lat < -90)
       {
@@ -542,7 +542,7 @@ namespace gpstk
    Position& Position::setGeocentric(const double lat,
                                      const double lon,
                                      const double rad)
-      throw(GeometryException)
+      noexcept(false)
    {
       if(lat > 90 || lat < -90)
       {
@@ -578,7 +578,7 @@ namespace gpstk
    Position& Position::setSpherical(const double theta,
                                     const double phi,
                                     const double rad)
-      throw(GeometryException)
+      noexcept(false)
    {
       if(theta < 0 || theta > 180)
       {
@@ -614,7 +614,7 @@ namespace gpstk
    Position& Position::setECEF(const double X,
                                const double Y,
                                const double Z)
-      throw()
+      noexcept
    {
       theArray[0] = X;
       theArray[1] = Y;
@@ -670,7 +670,7 @@ namespace gpstk
       // @return a reference to this object.
    Position& Position::setToString(const std::string& str,
                                    const std::string& fmt)
-      throw(GeometryException,StringUtils::StringException)
+      noexcept(false)
    {
       try {
             // make an object to return (so we don't fiddle with *this
@@ -994,7 +994,7 @@ namespace gpstk
       // @return a string containing this Position in the
       // representation specified by \c fmt.
    std::string Position::printf(const char *fmt) const
-      throw(StringUtils::StringException)
+      noexcept(false)
    {
       string rv = fmt;
       rv = formattedPrint(rv, string("%[ 0-]?[[:digit:]]*(\\.[[:digit:]]+)?x"),
@@ -1044,7 +1044,7 @@ namespace gpstk
 
       // Returns the string that operator<<() would print.
    string Position::asString() const
-      throw(StringUtils::StringException)
+      noexcept(false)
    {
       ostringstream o;
       o << *this;
@@ -1059,7 +1059,7 @@ namespace gpstk
       // Algorithm references: standard geometry.
    void Position::convertSphericalToCartesian(const Triple& tpr,
                                               Triple& xyz)
-      throw()
+      noexcept
    {
       double st=::sin(tpr[0]*DEG_TO_RAD);
       xyz[0] = tpr[2]*st*::cos(tpr[1]*DEG_TO_RAD);
@@ -1073,7 +1073,7 @@ namespace gpstk
       // Algorithm references: standard geometry.
    void Position::convertCartesianToSpherical(const Triple& xyz,
                                               Triple& tpr)
-      throw()
+      noexcept
    {
       tpr[2] = RSS(xyz[0],xyz[1],xyz[2]);
       if(tpr[2] <= Position::POSITION_TOLERANCE/5) { // zero-length Cartesian vector
@@ -1104,7 +1104,7 @@ namespace gpstk
                                              Triple& llh,
                                              const double A,
                                              const double eccSq)
-      throw()
+      noexcept
    {
       double p,slat,N,htold,latold;
       p = SQRT(xyz[0]*xyz[0]+xyz[1]*xyz[1]);
@@ -1143,7 +1143,7 @@ namespace gpstk
                                              Triple& xyz,
                                              const double A,
                                              const double eccSq)
-      throw()
+      noexcept
    {
       double slat = ::sin(llh[0]*DEG_TO_RAD);
       double clat = ::cos(llh[0]*DEG_TO_RAD);
@@ -1159,7 +1159,7 @@ namespace gpstk
       //            geocentric lat(deg N),lon(deg E),radius (units of input)
    void Position::convertCartesianToGeocentric(const Triple& xyz,
                                                Triple& llr)
-      throw()
+      noexcept
    {
       convertCartesianToSpherical(xyz, llr);
       llr[0] = 90 - llr[0];         // convert theta to latitude
@@ -1170,7 +1170,7 @@ namespace gpstk
       // @param xyz (output): X,Y,Z (units of radius)
    void Position::convertGeocentricToCartesian(const Triple& llr,
                                                Triple& xyz)
-      throw()
+      noexcept
    {
       Triple llh(llr);
       llh[0] = 90 - llh[0];         // convert latitude to theta
@@ -1187,7 +1187,7 @@ namespace gpstk
                                                Triple& llh,
                                                const double A,
                                                const double eccSq)
-      throw()
+      noexcept
    {
       double cl,p,sl,slat,N,htold,latold;
       llh[1] = llr[1];   // longitude is unchanged
@@ -1233,7 +1233,7 @@ namespace gpstk
                                               Triple& llr,
                                               const double A,
                                               const double eccSq)
-      throw()
+      noexcept
    {
       double slat = ::sin(llh[0]*DEG_TO_RAD);
       double N = A/SQRT(1.0-eccSq*slat*slat);
@@ -1288,7 +1288,7 @@ namespace gpstk
       // @throw GeometryException if ell values differ
    double range(const Position& A,
                 const Position& B)
-      throw(GeometryException)
+      noexcept(false)
    {
       if(A.AEarth != B.AEarth || A.eccSquared != B.eccSquared)
       {
@@ -1309,7 +1309,7 @@ namespace gpstk
    double Position::radiusEarth(const double geolat,
                                 const double A,
                                 const double eccSq)
-      throw()
+      noexcept
    {
       double slat=::sin(DEG_TO_RAD*geolat);
       double e=(1.0-eccSq);
@@ -1323,7 +1323,7 @@ namespace gpstk
       //        computed elevation, as seen from this Position.
       // @return the elevation in degrees
    double Position::elevation(const Position& Target) const
-      throw(GeometryException)
+      noexcept(false)
    {
       Position R(*this),S(Target);
       R.transformTo(Cartesian);
@@ -1347,7 +1347,7 @@ namespace gpstk
       //        computed elevation, as seen from this Position.
       // @return the elevation in degrees
    double Position::elevationGeodetic(const Position& Target) const
-      throw(GeometryException)
+      noexcept(false)
    {
       Position R(*this),S(Target);
       double latGeodetic = R.getGeodeticLatitude()*DEG_TO_RAD;
@@ -1382,7 +1382,7 @@ namespace gpstk
       //        computed azimuth, as seen from this Position.
       // @return the azimuth in degrees
    double Position::azimuth(const Position& Target) const
-      throw(GeometryException)
+      noexcept(false)
    {
       Position R(*this),S(Target);
       R.transformTo(Cartesian);
@@ -1409,7 +1409,7 @@ namespace gpstk
       //        computed azimuth, as seen from this Position.
       // @return the azimuth in degrees
    double Position::azimuthGeodetic(const Position& Target) const
-      throw(GeometryException)
+      noexcept(false)
    {
       Position R(*this),S(Target);
       double latGeodetic = R.getGeodeticLatitude()*DEG_TO_RAD;
@@ -1471,7 +1471,7 @@ namespace gpstk
    Position Position::getIonosphericPiercePoint(const double elev,
                                                 const double azim,
                                                 const double ionoht) const
-      throw()
+      noexcept
    {
       Position Rx(*this);
 
@@ -1506,7 +1506,7 @@ namespace gpstk
         * @return radius of curvature of the meridian (in meters)
         */
     double Position::getCurvMeridian() const
-        throw()
+        noexcept
     {
     
         double slat = ::sin(geodeticLatitude()*DEG_TO_RAD);
@@ -1522,7 +1522,7 @@ namespace gpstk
         * @return radius of curvature in the prime vertical (in meters)
         */
     double Position::getCurvPrimeVertical() const
-        throw()
+        noexcept
     {
     
         double slat = ::sin(geodeticLatitude()*DEG_TO_RAD);
@@ -1546,7 +1546,7 @@ namespace gpstk
                   Position::CoordinateSystem s,
                   EllipsoidModel *ell,
                   ReferenceFrame frame)
-      throw(GeometryException)
+      noexcept(false)
    {
       double bb(b);
       if(s == Geodetic || s==Geocentric)

--- a/core/lib/GNSSCore/Position.hpp
+++ b/core/lib/GNSSCore/Position.hpp
@@ -61,7 +61,7 @@ namespace gpstk
 
       // forward declarations
    class Position;
-   double range(const Position& A, const Position& B) throw(GeometryException);
+   double range(const Position& A, const Position& B) noexcept(false);
    
       /**
        * A position representation class for common 3D geographic
@@ -153,7 +153,7 @@ namespace gpstk
 
          /// return string giving name of coordinate system
       std::string getSystemName()
-         throw();
+         noexcept;
 
          // ----------- Part  2: member functions: tolerance ------------------
          //
@@ -184,7 +184,7 @@ namespace gpstk
           * @sa Position-Specific Definitions
           */
       Position& setTolerance(const double tol)
-         throw();
+         noexcept;
 
          // ----------- Part  3: member functions: constructors ---------------
          //
@@ -193,7 +193,7 @@ namespace gpstk
           * Initializes to zero, Unknown coordinates
           */
       Position()
-      throw();
+      noexcept;
 
          /**
           * Explicit constructor. Coordinate system may be specified
@@ -213,7 +213,7 @@ namespace gpstk
                CoordinateSystem s = Cartesian,
                EllipsoidModel *ell = NULL,
                ReferenceFrame frame = ReferenceFrame::Unknown)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Explicit constructor. Coordinate system may be specified
@@ -229,7 +229,7 @@ namespace gpstk
                CoordinateSystem s = Cartesian,
                EllipsoidModel *ell = NULL,
                ReferenceFrame frame = ReferenceFrame::Unknown)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Explicit constructor. Coordinate system may be specified
@@ -245,7 +245,7 @@ namespace gpstk
                CoordinateSystem s = Cartesian,
                EllipsoidModel *ell = NULL,
                ReferenceFrame frame = ReferenceFrame::Unknown)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Explicit constructor from Xvt. The coordinate system is Cartesian,
@@ -253,11 +253,11 @@ namespace gpstk
           * @param xvt Input Xvt object, xvt.x contains the Cartesian coordinates
           */
       Position(const Xvt& xvt)
-         throw();
+         noexcept;
 
          /// Destructor.
       ~Position()
-      throw()
+      noexcept
       {}
 
          // ----------- Part  4: member functions: arithmetic -----------------
@@ -269,7 +269,7 @@ namespace gpstk
           * @return new Position, in the original system.
           */
       Position& operator-=(const Position& right)
-         throw();
+         noexcept;
 
          /** Add a Position to this Position. Perform the addition in
           * Cartesian coordinates, but return this Position to the system it
@@ -278,7 +278,7 @@ namespace gpstk
           * @return new Position, in the original system.
           */
       Position& operator+=(const Position& right)
-         throw();
+         noexcept;
 
          /**
           * Difference two Positions, returning result as a Position
@@ -289,7 +289,7 @@ namespace gpstk
           */
       friend Position operator-(const Position& left,
                                 const Position& right)
-         throw();
+         noexcept;
 
          /**
           * Add two Positions, returning result as a Position in Cartesian
@@ -299,7 +299,7 @@ namespace gpstk
           */
       friend Position operator+(const Position& left,
                                 const Position& right)
-         throw();
+         noexcept;
 
          /** Multiply a Position by a double scalar on the left.
           * @param right Position to be multiplied by the scalar
@@ -354,14 +354,14 @@ namespace gpstk
           * tolerance. Return false if ellipsoid values differ.
           * @param right Position to be compared to this Position */
       bool operator==(const Position &right) const
-         throw();
+         noexcept;
 
          /** Inequality operator. Return true if range between this
           * Position and the input Position is greater than
           * tolerance. Return true if ellipsoid values differ.
           * @param right Position to be compared to this Position */
       bool operator!=(const Position &right) const
-         throw();
+         noexcept;
 
          // ----------- Part  6: member functions: coordinate transformations -
          //
@@ -372,19 +372,19 @@ namespace gpstk
           * @param sys CoordinateSystem into which this Position is transformed
           */
       Position transformTo(CoordinateSystem sys)
-         throw();
+         noexcept;
   
          /// Convert to geodetic coordinates (does nothing if
          /// system == Geodetic already).
       Position asGeodetic()
-         throw()
+         noexcept
       { transformTo(Geodetic); return *this; }
 
          /// Convert to another ell, then to geodetic coordinates.
          /// @return a reference to this.
          /// @throw GeometryException if input is NULL.
       Position asGeodetic(EllipsoidModel *ell)
-         throw(GeometryException)
+         noexcept(false)
       {
          try { setEllipsoidModel(ell); }
          catch(GeometryException& ge) { GPSTK_RETHROW(ge); }
@@ -395,7 +395,7 @@ namespace gpstk
          /// Convert to cartesian coordinates (does nothing if
          /// system == Cartesian already).
       Position asECEF()
-         throw()
+         noexcept
       { transformTo(Cartesian); return *this; }
 
 
@@ -407,110 +407,110 @@ namespace gpstk
 
          /// return coordinate ReferenceFrame
       const ReferenceFrame& getReferenceFrame() const
-         throw();
+         noexcept;
       
          /// return X coordinate (meters)
       double X() const
-         throw();
+         noexcept;
 
          /// return Y coordinate (meters)
       double Y() const
-         throw();
+         noexcept;
 
          /// return Z coordinate (meters)
       double Z() const
-         throw();
+         noexcept;
 
          /// return geodetic latitude (degrees North).
       double geodeticLatitude() const
-         throw();
+         noexcept;
 
          /// return geocentric latitude (degrees North);
          /// equal to 90 degress - theta in regular spherical coordinates.
       double geocentricLatitude() const
-         throw();
+         noexcept;
 
          /// return spherical coordinate theta in degrees
       double theta() const
-         throw();
+         noexcept;
 
          /// return spherical coordinate phi in degrees
       double phi() const
-         throw();
+         noexcept;
 
          /// return longitude (degrees East);
          /// equal to phi in regular spherical coordinates.
       double longitude() const
-         throw();
+         noexcept;
 
          /// return distance from the center of Earth (meters),
          /// Same as radius in spherical coordinates.
       double radius() const
-         throw();
+         noexcept;
 
          /// return height above ellipsoid (meters) (Geodetic).
       double height() const
-         throw();
+         noexcept;
 
          /// return the coordinate system for this Position
       CoordinateSystem getCoordinateSystem() const
-         throw() 
+         noexcept 
       { return system; };
 
          /// return geodetic latitude (deg N)
       double getGeodeticLatitude() const
-         throw()
+         noexcept
       { return geodeticLatitude(); }
 
          /// return geocentric latitude (deg N)
       double getGeocentricLatitude() const
-         throw()
+         noexcept
       { return geocentricLatitude(); }
 
          /// return longitude (deg E) (either geocentric or geodetic)
       double getLongitude() const
-         throw()
+         noexcept
       { return longitude(); }
 
          /// return height above ellipsoid (meters)
       double getAltitude() const
-         throw()
+         noexcept
       { return height(); }
 
          /// return height above ellipsoid (meters)
       double getHeight() const
-         throw()
+         noexcept
       { return height(); }
 
          /// return ECEF X coordinate (meters)
       double getX() const
-         throw()
+         noexcept
       { return X(); }
 
          /// return ECEF Y coordinate (meters)
       double getY() const
-         throw()
+         noexcept
       { return Y(); }
 
          /// return ECEF Z coordinate (meters)
       double getZ() const
-         throw()
+         noexcept
       { return Z(); }
 
          /** @return spherical coordinate angle theta (deg) (90 -
           * geocentric latitude) */
       double getTheta() const
-         throw()
+         noexcept
       { return theta(); }
 
          /// return spherical coordinate angle phi (deg) (same as longitude)
       double getPhi() const
-         throw()
+         noexcept
       { return phi(); }
 
          /// return radius
       double getRadius() const
-         throw()
+         noexcept
       { return radius(); }
 
          // ----------- Part  8: member functions: set ------------------------
@@ -520,7 +520,7 @@ namespace gpstk
           * @param frame The ReferenceFrame to set to.
           */
       void setReferenceFrame(const ReferenceFrame& frame)
-         throw();
+         noexcept;
 
          /**
           * Set the ellipsoid values for this Position given a ellipsoid.
@@ -528,7 +528,7 @@ namespace gpstk
           * @throw      GeometryException if input is NULL.
           */
       void setEllipsoidModel(const EllipsoidModel *ell)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Set the Position given geodetic coordinates; system is set
@@ -543,7 +543,7 @@ namespace gpstk
                             const double lon,
                             const double ht,
                             const EllipsoidModel *ell = NULL)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Set the Position given geocentric coordinates; system is
@@ -557,7 +557,7 @@ namespace gpstk
       Position& setGeocentric(const double lat,
                               const double lon,
                               const double rad)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Set the Position given spherical coordinates; system is
@@ -571,7 +571,7 @@ namespace gpstk
       Position& setSpherical(const double theta,
                              const double phi,
                              const double rad)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Set the Position given ECEF coordinates; system is set to
@@ -584,7 +584,7 @@ namespace gpstk
       Position& setECEF(const double X,
                         const double Y,
                         const double Z)
-         throw();
+         noexcept;
 
          /**
           * Set the Position given an array of ECEF coordinates;
@@ -593,7 +593,7 @@ namespace gpstk
           * @return a reference to this object.
           */
       Position& setECEF(const double XYZ[3])
-         throw()
+         noexcept
       { return setECEF(XYZ[0],XYZ[1],XYZ[2]); }
 
          /**
@@ -603,7 +603,7 @@ namespace gpstk
           * @return a reference to this object.
           */
       Position& setECEF(const Triple& XYZ)
-         throw()
+         noexcept
       { return setECEF(XYZ[0],XYZ[1],XYZ[2]); }
 
          // ----------- Part 9: member functions: setToString, printf ---------
@@ -659,8 +659,7 @@ namespace gpstk
           */
       Position& setToString(const std::string& str,
                             const std::string& fmt)
-         throw(GeometryException,
-               StringUtils::StringException);
+         noexcept(false);
 
 
          // if you can see this, ignore the \'s below, as they are for
@@ -698,17 +697,17 @@ namespace gpstk
           * representation specified by \c fmt.
           */
       std::string printf(const char *fmt) const
-         throw(StringUtils::StringException);
+         noexcept(false);
 
          /// Format this time into a string.
          /// @see printf(const char*)
       std::string printf(const std::string& fmt) const
-         throw(StringUtils::StringException) 
+         noexcept(false) 
       { return printf(fmt.c_str()); }
 
          /// Returns the string that operator<<() would print.
       std::string asString() const
-         throw(StringUtils::StringException);
+         noexcept(false);
 
          // ----------- Part 10: functions: fundamental conversions -----------
          // 
@@ -719,7 +718,7 @@ namespace gpstk
           */
       static void convertSphericalToCartesian(const Triple& tpr,
                                               Triple& xyz)
-         throw();
+         noexcept;
 
          /** Fundamental routine to convert cartesian to spherical coordinates.
           * The zero vector is converted to (90,0,0).
@@ -729,7 +728,7 @@ namespace gpstk
           */
       static void convertCartesianToSpherical(const Triple& xyz,
                                               Triple& tpr)
-         throw();
+         noexcept;
 
 
          /** Fundamental routine to convert ECEF (cartesian) to
@@ -747,7 +746,7 @@ namespace gpstk
                                              Triple& llh,
                                              const double A,
                                              const double eccSq)
-         throw();
+         noexcept;
 
          /** Fundamental routine to convert geodetic to ECEF
           * (cartesian) coordinates, (Ellipsoid specified by
@@ -763,7 +762,7 @@ namespace gpstk
                                              Triple& xyz,
                                              const double A,
                                              const double eccSq)
-         throw();
+         noexcept;
 
 
          /** Fundamental routine to convert cartesian (ECEF) to geocentric
@@ -774,7 +773,7 @@ namespace gpstk
           */
       static void convertCartesianToGeocentric(const Triple& xyz,
                                                Triple& llr)
-         throw();
+         noexcept;
 
          /** Fundamental routine to convert geocentric to cartesian (ECEF)
           * @param llr (input): geocentric lat(deg N),lon(deg E),radius
@@ -782,7 +781,7 @@ namespace gpstk
           */
       static void convertGeocentricToCartesian(const Triple& llr,
                                                Triple& xyz)
-         throw();
+         noexcept;
 
 
          /** Fundamental routine to convert geocentric to geodetic
@@ -796,7 +795,7 @@ namespace gpstk
                                               Triple& geodeticllh,
                                               const double A,
                                               const double eccSq)
-         throw();
+         noexcept;
 
          /** Fundamental routine to convert geodetic to geocentric 
           * @param geodeticllh (input): geodetic latitude (deg N),
@@ -809,7 +808,7 @@ namespace gpstk
                                               Triple& llr,
                                               const double A,
                                               const double eccSq)
-         throw();
+         noexcept;
 
          // ----------- Part 11: operator<< and other useful functions --------
          //
@@ -832,7 +831,7 @@ namespace gpstk
           */
       friend double range(const Position& A,
                           const Position& B)
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * Compute the radius of the ellipsoidal Earth, given the
@@ -843,7 +842,7 @@ namespace gpstk
       static double radiusEarth(const double geolat,
                                 const double A,
                                 const double eccSq)
-         throw();
+         noexcept;
 
          /**
           * A member function that calls the non-member radiusEarth() for
@@ -851,7 +850,7 @@ namespace gpstk
           * @return the Earth radius (in meters)
           */
       double radiusEarth() const
-         throw()
+         noexcept
       {
          Position p(*this);
          p.transformTo(Position::Geodetic);
@@ -866,7 +865,7 @@ namespace gpstk
           * @return the elevation in degrees
           */
       double elevation(const Position& Target) const
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * A member function that computes the elevation of the input
@@ -877,7 +876,7 @@ namespace gpstk
           * @return the elevation in degrees
           */
       double elevationGeodetic(const Position& Target) const
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * A member function that computes the azimuth of the input
@@ -887,7 +886,7 @@ namespace gpstk
           * @return the azimuth in degrees
           */
       double azimuth(const Position& Target) const
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * A member function that computes the azimuth of the input
@@ -898,7 +897,7 @@ namespace gpstk
           * @return the azimuth in degrees
           */
       double azimuthGeodetic(const Position& Target) const
-         throw(GeometryException);
+         noexcept(false);
 
          /**
           * A member function that computes the position at which a
@@ -919,7 +918,7 @@ namespace gpstk
       Position getIonosphericPiercePoint(const double elev,
                                          const double azim,
                                          const double ionoht) const
-         throw();
+         noexcept;
 
          /**
           * A member function that computes the radius of curvature of the 
@@ -927,7 +926,7 @@ namespace gpstk
           * @return radius of curvature of the meridian (in meters)
           */
       double getCurvMeridian() const
-         throw();
+         noexcept;
 
          /**
           * A member function that computes the radius of curvature in the 
@@ -935,7 +934,7 @@ namespace gpstk
           * @return radius of curvature in the prime vertical (in meters)
           */
       double getCurvPrimeVertical() const
-         throw();
+         noexcept;
 
          // ----------- Part 12: private functions and member data ------------
          //
@@ -955,7 +954,7 @@ namespace gpstk
                       CoordinateSystem s = Cartesian,
                       EllipsoidModel *ell = NULL,
                       ReferenceFrame frame = ReferenceFrame::Unknown)
-         throw(GeometryException);
+         noexcept(false);
 
          /* Values of the coordinates, defined for each system as follows;
           *    Cartesian  : X,Y,Z in meters

--- a/core/lib/GNSSCore/SaasTropModel.cpp
+++ b/core/lib/GNSSCore/SaasTropModel.cpp
@@ -129,7 +129,7 @@ namespace gpstk
    SaasTropModel::SaasTropModel(const double& lat,
                                 const int& day,
                                 const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       validRxHeight = false;
       SaasTropModel::setReceiverLatitude(lat);
@@ -148,7 +148,7 @@ namespace gpstk
                                 const double& T,
                                 const double& P,
                                 const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       validRxHeight = false;
       SaasTropModel::setReceiverLatitude(lat);
@@ -158,7 +158,7 @@ namespace gpstk
 
       // re-define this to get the throws correct
    double SaasTropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       if(!valid) {
          if(!validWeather) GPSTK_THROW(
@@ -198,7 +198,7 @@ namespace gpstk
    double SaasTropModel::correction(const Position& RX,
                                     const Position& SV,
                                     const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       SaasTropModel::setReceiverHeight(RX.getHeight());
       SaasTropModel::setReceiverLatitude(RX.getGeodeticLatitude());
@@ -229,7 +229,7 @@ namespace gpstk
    double SaasTropModel::correction(const Xvt& RX,
                                     const Xvt& SV,
                                     const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       Position R(RX),S(SV);
       return SaasTropModel::correction(R,S,tt);
@@ -237,7 +237,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for dry component of the troposphere
    double SaasTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -248,7 +248,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for wet component of the troposphere
    double SaasTropModel::wet_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
 
@@ -273,7 +273,7 @@ namespace gpstk
       // Compute and return the mapping function for dry component of the troposphere
       // @param elevation Elevation of satellite as seen at receiver, in degrees
    double SaasTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       if(elevation < 0.0) return 0.0;
@@ -324,7 +324,7 @@ namespace gpstk
       // Compute and return the mapping function for wet component of the troposphere
       // @param elevation Elevation of satellite as seen at receiver, in degrees.
    double SaasTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID_DETAILED();
       if(elevation < 0.0) return 0.0;
@@ -364,7 +364,7 @@ namespace gpstk
    void SaasTropModel::setWeather(const double& T,
                                   const double& P,
                                   const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       temp = T;
       press = P;
@@ -381,7 +381,7 @@ namespace gpstk
       // Typically called just before correction().
       // @param wx the weather to use for this correction
    void SaasTropModel::setWeather(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/GNSSCore/SaasTropModel.hpp
+++ b/core/lib/GNSSCore/SaasTropModel.hpp
@@ -86,7 +86,7 @@ namespace gpstk
       SaasTropModel(const double& lat,
                     const int& day,
                     const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a tropospheric model from explicit weather data
          /// @param lat Latitude of the receiver in degrees.
@@ -99,7 +99,7 @@ namespace gpstk
                     const double& T,
                     const double& P,
                     const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
       /// Return the name of the model
       virtual std::string name(void)
@@ -108,7 +108,7 @@ namespace gpstk
          /// Compute and return the full tropospheric delay
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /**
           * Compute and return the full tropospheric delay, given the positions of
@@ -124,7 +124,7 @@ namespace gpstk
       virtual double correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /** \deprecated
           * Compute and return the full tropospheric delay, given the positions of
@@ -140,35 +140,35 @@ namespace gpstk
       virtual double correction(const Xvt& RX,
                                 const Xvt& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for dry component
          /// of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for wet component
          /// of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for dry component of
          /// the troposphere. NB this function will return infinity at zero elevation.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for wet component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
          /// @param wx the weather to use for this correction
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Define the weather data; typically called just before correction().
          /// @param T temperature in degrees Celsius
@@ -177,7 +177,7 @@ namespace gpstk
       virtual void setWeather(const double& T,
                               const double& P,
                               const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Define the receiver height; this required before calling
          /// correction() or any of the zenith_delay or mapping_function routines.

--- a/core/lib/GNSSCore/SimpleTropModel.cpp
+++ b/core/lib/GNSSCore/SimpleTropModel.cpp
@@ -56,7 +56,7 @@ namespace gpstk
       // Creates a trop model from a weather observation
       // @param wx the weather to use for this correction.
    SimpleTropModel::SimpleTropModel(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       setWeather(wx);
       valid = true;
@@ -69,7 +69,7 @@ namespace gpstk
    SimpleTropModel::SimpleTropModel(const double& T,
                                     const double& P,
                                     const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       setWeather(T,P,H);
       valid = true;
@@ -83,7 +83,7 @@ namespace gpstk
    void SimpleTropModel::setWeather(const double& T,
                                     const double& P,
                                     const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       TropModel::setWeather(T,P,H);
       GPSEllipsoid ell;
@@ -99,14 +99,14 @@ namespace gpstk
       // Typically called just before correction().
       // @param wx the weather to use for this correction
    void SimpleTropModel::setWeather(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       TropModel::setWeather(wx);
    }
 
       // Compute and return the zenith delay for dry component of the troposphere
    double SimpleTropModel::dry_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
       return Cdrydelay;
@@ -114,7 +114,7 @@ namespace gpstk
 
       // Compute and return the zenith delay for wet component of the troposphere
    double SimpleTropModel::wet_zenith_delay(void) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
       return Cwetdelay;
@@ -125,7 +125,7 @@ namespace gpstk
       // @param elevation is the Elevation of satellite as seen at receiver,
       //                  in degrees
    double SimpleTropModel::dry_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -141,7 +141,7 @@ namespace gpstk
       // @param elevation is the Elevation of satellite as seen at receiver,
       //                  in degrees
    double SimpleTropModel::wet_mapping_function(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 

--- a/core/lib/GNSSCore/SimpleTropModel.hpp
+++ b/core/lib/GNSSCore/SimpleTropModel.hpp
@@ -53,7 +53,7 @@ namespace gpstk
          /// Creates a trop model, with weather observation input
          /// @param wx the weather to use for this correction.
       SimpleTropModel(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Create a tropospheric model from explicit weather data
          /// @param T temperature in degrees Celsius
@@ -62,7 +62,7 @@ namespace gpstk
       SimpleTropModel(const double& T,
                       const double& P,
                       const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Return the name of the model
       virtual std::string name(void)
@@ -70,23 +70,23 @@ namespace gpstk
 
          /// Compute and return the zenith delay for dry component of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the zenith delay for wet component of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for dry component
          /// of the troposphere
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Compute and return the mapping function for wet component
          /// of the troposphere
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
@@ -96,13 +96,13 @@ namespace gpstk
       virtual void setWeather(const double& T,
                               const double& P,
                               const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
          /// @param wx the weather to use for this correction
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
    private:
       double Cdrydelay;

--- a/core/lib/GNSSCore/TropModel.cpp
+++ b/core/lib/GNSSCore/TropModel.cpp
@@ -58,7 +58,7 @@ namespace gpstk
       // setWeather(T,P,H) before making this call.
       // @param elevation Elevation of satellite as seen at receiver, in degrees
    double TropModel::correction(double elevation) const
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -82,7 +82,7 @@ namespace gpstk
    double TropModel::correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-      throw(InvalidTropModel)
+      noexcept(false)
    {
       THROW_IF_INVALID();
 
@@ -106,7 +106,7 @@ namespace gpstk
    void TropModel::setWeather(const double& T,
                               const double& P,
                               const double& H)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       temp = T + CELSIUS_TO_KELVIN;
       press = P;
@@ -141,7 +141,7 @@ namespace gpstk
       // Typically called just before correction().
       // @param wx the weather to use for this correction
    void TropModel::setWeather(const WxObservation& wx)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       if (wx.isAllValid())
       {

--- a/core/lib/GNSSCore/TropModel.hpp
+++ b/core/lib/GNSSCore/TropModel.hpp
@@ -114,7 +114,7 @@ namespace gpstk
          /// Compute and return the full tropospheric delay
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double correction(double elevation) const
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /**
           * Compute and return the full tropospheric delay, given the positions of
@@ -130,7 +130,7 @@ namespace gpstk
       virtual double correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel);
+         noexcept(false);
 
          /** \deprecated
           * Compute and return the full tropospheric delay, given the positions of
@@ -146,29 +146,29 @@ namespace gpstk
       virtual double correction(const Xvt& RX,
                                 const Xvt& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel)
+         noexcept(false)
       { Position R(RX),S(SV);  return TropModel::correction(R,S,tt); }
 
          /// Compute and return the zenith delay for hydrostatic (dry)
          /// component of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel) = 0;
+         noexcept(false) = 0;
 
          /// Compute and return the zenith delay for wet component of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel) = 0;
+         noexcept(false) = 0;
 
          /// Compute and return the mapping function for hydrostatic (dry)
          /// component of the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation)
-         const throw(InvalidTropModel) = 0;
+         const noexcept(false) = 0;
 
          /// Compute and return the mapping function for wet component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation)
-         const throw(InvalidTropModel) = 0;
+         const noexcept(false) = 0;
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
@@ -178,13 +178,13 @@ namespace gpstk
       virtual void setWeather(const double& T,
                               const double& P,
                               const double& H)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Re-define the tropospheric model with explicit weather data.
          /// Typically called just before correction().
          /// @param wx the weather to use for this correction
       virtual void setWeather(const WxObservation& wx)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /// Define the receiver height; this required by some models before calling
          /// correction() or any of the zenith_delay or mapping_function routines.
@@ -256,7 +256,7 @@ namespace gpstk
          /// Compute and return the full tropospheric delay
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double correction(double elevation) const
-         throw(InvalidTropModel)
+         noexcept(false)
          { return 0.0; }
 
          /**
@@ -273,7 +273,7 @@ namespace gpstk
       virtual double correction(const Position& RX,
                                 const Position& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel)
+         noexcept(false)
          { return 0.0; }
 
          /** \deprecated
@@ -290,32 +290,32 @@ namespace gpstk
       virtual double correction(const Xvt& RX,
                                 const Xvt& SV,
                                 const CommonTime& tt)
-         throw(InvalidTropModel)
+         noexcept(false)
          { return 0.0; }
 
          /// Compute and return the zenith delay for hydrostatic (dry)
          /// component of the troposphere
       virtual double dry_zenith_delay(void) const
-         throw(InvalidTropModel)
+         noexcept(false)
          { return 0.0; }
 
          /// Compute and return the zenith delay for wet component of the troposphere
       virtual double wet_zenith_delay(void) const
-         throw(InvalidTropModel)
+         noexcept(false)
          { return 0.0; }
 
          /// Compute and return the mapping function for hydrostatic (dry)
          /// component of the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double dry_mapping_function(double elevation)
-         const throw(InvalidTropModel)
+         const noexcept(false)
          { return 0.0; }
 
          /// Compute and return the mapping function for wet component of
          /// the troposphere.
          /// @param elevation Elevation of satellite as seen at receiver, in degrees
       virtual double wet_mapping_function(double elevation)
-         const throw(InvalidTropModel)
+         const noexcept(false)
          { return 0.0; }
 
    }; // end class ZeroTropModel

--- a/core/lib/GNSSCore/WGS84Ellipsoid.hpp
+++ b/core/lib/GNSSCore/WGS84Ellipsoid.hpp
@@ -57,58 +57,58 @@ namespace gpstk
    
          /// Defined in TR8350.2, Appendix A.1
          /// @return semi-major axis of Earth in meters.
-      virtual double a() const throw()
+      virtual double a() const noexcept
       { return 6378137.0; }
 
          /// Derived from TR8350.2, Appendix A.1
          /// @return semi-major axis of Earth in km.
-      virtual double a_km() const throw()
+      virtual double a_km() const noexcept
       { return a() / 1000.0; }
 
          /**
           * Derived from TR8350.2, Appendix A.1
           * @return flattening (ellipsoid parameter).
           */
-      virtual double flattening() const throw()
+      virtual double flattening() const noexcept
       { return 0.335281066475e-2; }
 
          /// Defined in TR8350.2, Table 3.3
          /// @return eccentricity (ellipsoid parameter).
-      virtual double eccentricity() const throw()
+      virtual double eccentricity() const noexcept
       { return 8.1819190842622e-2; }
 
          /// Defined in TR8350.2, Table 3.3
          /// @return eccentricity squared (ellipsoid parameter).
-      virtual double eccSquared() const throw()
+      virtual double eccSquared() const noexcept
       { return 6.69437999014e-3; }
 
          /// Defined in TR8350.2, 3.2.4 line 3-6, or Table 3.1
          /// @return angular velocity of Earth in radians/sec.
-      virtual double angVelocity() const throw()
+      virtual double angVelocity() const noexcept
       { return 7.292115e-5; }
 
          /// Defined in TR8350.2, Table 3.1
          /// @return geocentric gravitational constant in m**3 / s**2
-      virtual double gm() const throw()
+      virtual double gm() const noexcept
       { return 3986004.418e8; }
 
          /// Derived from TR8350.2, Table 3.1
          /// @return geocentric gravitational constant in km**3 / s**2
-      virtual double gm_km() const throw()
+      virtual double gm_km() const noexcept
       { return 398600.4418; }
 
          /// Defined in TR8350.2, 3.3.2 line 3-11
          /// @return Speed of light in m/s.
-      virtual double c() const throw()
+      virtual double c() const noexcept
       { return 299792458; }
 
          /// Derived from TR8350.2, 3.3.2 line 3-11
          /// @return Speed of light in km/s
-      virtual double c_km() const throw()
+      virtual double c_km() const noexcept
       { return c()/1000.0; }
 
       /// Destructor.
-      virtual ~WGS84Ellipsoid() throw() {};
+      virtual ~WGS84Ellipsoid() noexcept {};
 
    }; // class WGS84Ellipsoid
 

--- a/core/lib/GNSSCore/WxObsMap.cpp
+++ b/core/lib/GNSSCore/WxObsMap.cpp
@@ -49,7 +49,7 @@ namespace gpstk
 {
 
    WxObservation WxObsData::getMostRecent( const CommonTime& t ) const
-      throw()
+      noexcept
    {
       if(obs.size() == 0)
          return WxObservation();
@@ -63,7 +63,7 @@ namespace gpstk
    };
 
    void WxObsData::insertObservation( const WxObservation& wx )
-      throw()
+      noexcept
    {
       obs[wx.t] = wx;
       if (wx.t > lastTime)  lastTime=wx.t;
@@ -71,14 +71,14 @@ namespace gpstk
    }
 
    bool WxObservation::isAllValid() const
-      throw()
+      noexcept
    {
       return temperatureSource != noWx
          && pressureSource != noWx
          && humiditySource != noWx;
    };
 
-   void WxObsData::flush(const CommonTime& t) throw()
+   void WxObsData::flush(const CommonTime& t) noexcept
    {
       // remove data from the WxObsMap
       // map is sorted by time, stop removing data at
@@ -100,7 +100,7 @@ namespace gpstk
    WxObservation WxObsData::getWxObservation(const CommonTime& t,
                                              unsigned iv,
                                              bool interpolate) const
-      throw(ObjectNotFound)
+      noexcept(false)
    {
       if (obs.empty())
       {
@@ -229,7 +229,7 @@ namespace gpstk
 
    // These are just to facilitate debugging.
    std::ostream& operator<<(std::ostream& s, const gpstk::WxObservation& obs)
-      throw()
+      noexcept
    {
       // Note that this does not flag where the wx data came from
       s << obs.t << ", t=" << obs.temperature

--- a/core/lib/GNSSCore/WxObsMap.hpp
+++ b/core/lib/GNSSCore/WxObsMap.hpp
@@ -53,7 +53,7 @@ namespace gpstk
    struct WxObservation
    {
       /// Default Constructor
-      WxObservation() throw()
+      WxObservation() noexcept
          : t(CommonTime::END_OF_TIME), temperatureSource(noWx),
            pressureSource(noWx), humiditySource(noWx)
       {}
@@ -68,7 +68,7 @@ namespace gpstk
                     float temp, 
                     float pres, 
                     float humid)
-         throw()
+         noexcept
          :t(t),
           temperature(temp), pressure(pres),
           humidity(humid), temperatureSource(obsWx),
@@ -96,7 +96,7 @@ namespace gpstk
       /** Return whether all weather values in this object are valid.
        * @return whether all weather values in this object are valid
        */
-      bool isAllValid() const throw();
+      bool isAllValid() const noexcept;
 
       /** Friendly Output Operator.
        * @param s the output stream to which data is sent
@@ -104,7 +104,7 @@ namespace gpstk
        * @return a reference to the modified ostream
        */
       friend std::ostream& operator<<(std::ostream& s, 
-                                      const WxObservation& obs) throw();
+                                      const WxObservation& obs) noexcept;
    };
 
 
@@ -116,7 +116,7 @@ namespace gpstk
    struct WxObsData
    {
       /// Constructor
-      WxObsData() throw()
+      WxObsData() noexcept
          :firstTime(CommonTime::END_OF_TIME), 
           lastTime(CommonTime::BEGINNING_OF_TIME) {}
      
@@ -133,18 +133,18 @@ namespace gpstk
       /** Get the last WxObservation made before time t.
        * @return the WxObservation coming before time t
        */
-      WxObservation getMostRecent(const CommonTime& t) const throw();
+      WxObservation getMostRecent(const CommonTime& t) const noexcept;
       
       /** Insert a WxObservation.
        * @param obs the WxObservation to insert.
        */
-      void insertObservation(const WxObservation& obs) throw();
+      void insertObservation(const WxObservation& obs) noexcept;
       
       /**
        * Removes all stored #WxObservation objects older than time \a t.
        * \param t remove #WxObservation objects older than this
        */
-      void flush(const CommonTime& t) throw();
+      void flush(const CommonTime& t) noexcept;
 
       /**
        * Find a #WxObservation object for time \a t.
@@ -165,7 +165,7 @@ namespace gpstk
       WxObservation getWxObservation(const CommonTime& t,
                                      unsigned iv = 3600,
                                      bool interpolate = true) const
-         throw(ObjectNotFound);
+         noexcept(false);
    };
 } // namespace
 #endif 

--- a/core/lib/GNSSCore/Xvt.cpp
+++ b/core/lib/GNSSCore/Xvt.cpp
@@ -45,7 +45,7 @@
 namespace gpstk
 {
 
-   std::ostream& operator<<(std::ostream& os, const gpstk::Xvt& xvt) throw()
+   std::ostream& operator<<(std::ostream& os, const gpstk::Xvt& xvt) noexcept
    {
       os << "x:" << xvt.x
          << ", v:" << xvt.v
@@ -57,7 +57,7 @@ namespace gpstk
    }
 
    std::ostream& operator<<(std::ostream& os, const Xvt::HealthStatus& health)
-      throw()
+      noexcept
    {
       switch (health)
       {
@@ -108,7 +108,7 @@ namespace gpstk
    double Xvt::preciseRho(const Triple& rxPos,
                           const EllipsoidModel& ellips,
                           double correction) const 
-      throw()
+      noexcept
    {
          // Compute initial time of flight estimate using the
          // geometric range at transmit time.  This fails to account

--- a/core/lib/GNSSCore/Xvt.hpp
+++ b/core/lib/GNSSCore/Xvt.hpp
@@ -107,23 +107,23 @@ namespace gpstk
       {}
 
          /// access the position, ECEF Cartesian in meters
-      Triple getPos() throw()
+      Triple getPos() noexcept
       { return x; }
 
          /// access the velocity in m/s
-      Triple getVel() throw()
+      Triple getVel() noexcept
       { return v; }
 
          /// access the clock bias, in second
-      double getClockBias() throw()
+      double getClockBias() noexcept
       { return clkbias; }
 
          /// access the clock drift, in second/second
-      double getClockDrift() throw()
+      double getClockDrift() noexcept
       { return clkdrift; }
 
          /// access the relativity correction, in seconds
-      double getRelativityCorr() throw()
+      double getRelativityCorr() noexcept
       { return relcorr; }
 
          /** Compute and return the relativity correction (-2R dot
@@ -142,7 +142,7 @@ namespace gpstk
           * @return Range in meters */
       double preciseRho(const Triple& rxPos, 
                         const EllipsoidModel& ellipsoid,
-                        double correction = 0) const throw();
+                        double correction = 0) const noexcept;
 
          // member data
 
@@ -164,7 +164,7 @@ namespace gpstk
        * @param[in,out] os output stream to which \c xvt is sent
        * @param[in] xvt Xvt that is sent to \c os
        */
-   std::ostream& operator<<(std::ostream& os, const Xvt& xvt) throw();
+   std::ostream& operator<<(std::ostream& os, const Xvt& xvt) noexcept;
 
       /**
        * Output operator for Xvt health status.
@@ -172,7 +172,7 @@ namespace gpstk
        * @param[in] health Health status that is sent to \c os
        */
    std::ostream& operator<<(std::ostream& os, const Xvt::HealthStatus& health)
-      throw();
+      noexcept;
 
 }  // end namespace gpstk
 

--- a/core/lib/GNSSEph/AlmOrbit.cpp
+++ b/core/lib/GNSSEph/AlmOrbit.cpp
@@ -47,7 +47,7 @@
 
 namespace gpstk
 {
-   AlmOrbit :: AlmOrbit() throw()
+   AlmOrbit :: AlmOrbit() noexcept
    {
       ecc = i_offset = OMEGAdot = Ahalf = OMEGA0 = w = M0 = AF0 = AF1 = 0.0;
 
@@ -69,7 +69,7 @@ namespace gpstk
    }
 
    Xvt AlmOrbit :: svXvt(const CommonTime& t) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       Xvt sv;
       GPSEllipsoid ell;
@@ -186,12 +186,12 @@ namespace gpstk
       return sv;
    }
 
-   CommonTime AlmOrbit::getTransmitTime() const throw()
+   CommonTime AlmOrbit::getTransmitTime() const noexcept
    {
       return GPSWeekSecond(getFullWeek(), xmit_time);
    }
 
-   short AlmOrbit::getFullWeek() const throw()
+   short AlmOrbit::getFullWeek() const noexcept
    {
          // return value of the transmit week for the given PRN
       short xmit_week = week;
@@ -204,7 +204,7 @@ namespace gpstk
       return xmit_week;
    }
 
-   CommonTime AlmOrbit::getToaTime() const throw()
+   CommonTime AlmOrbit::getToaTime() const noexcept
    {
       return GPSWeekSecond(week, Toa);
    }

--- a/core/lib/GNSSEph/AlmOrbit.hpp
+++ b/core/lib/GNSSEph/AlmOrbit.hpp
@@ -58,7 +58,7 @@ namespace gpstk
    {
    public:
          /// Default constructor, initialize to 0.
-      AlmOrbit() throw();
+      AlmOrbit() noexcept;
 
          /// Fill constructor for all fields.
       AlmOrbit(short prn, double aEcc, double ai_offset, double aOMEGAdot,
@@ -66,17 +66,17 @@ namespace gpstk
                double aAF0, double aAF1, long aToa, long axmit_time,
                short aweek, short aSV_health);
 
-      Xvt svXvt(const CommonTime& t) const throw(InvalidRequest);
+      Xvt svXvt(const CommonTime& t) const noexcept(false);
 
-      short getPRNID() const throw()
+      short getPRNID() const noexcept
       { return PRN; }
 
          /// returns full week of TRANSMIT TIME
-      short getFullWeek() const throw();
-      CommonTime getTransmitTime() const throw();
-      CommonTime getToaTime() const throw();
-      CommonTime getTimestamp() const throw() { return getToaTime(); }
-      short getSVHealth() const throw() { return SV_health; }
+      short getFullWeek() const noexcept;
+      CommonTime getTransmitTime() const noexcept;
+      CommonTime getToaTime() const noexcept;
+      CommonTime getTimestamp() const noexcept { return getToaTime(); }
+      short getSVHealth() const noexcept { return SV_health; }
 
       void dump(std::ostream& s = std::cout, int verbosity=1) const;
 

--- a/core/lib/GNSSEph/BrcClockCorrection.cpp
+++ b/core/lib/GNSSEph/BrcClockCorrection.cpp
@@ -50,7 +50,7 @@ namespace gpstk
    using namespace gpstk;
 
    BrcClockCorrection::BrcClockCorrection()
-      throw()
+      noexcept
    {
       dataLoaded = false;
 
@@ -93,7 +93,7 @@ namespace gpstk
 
 
    bool BrcClockCorrection::operator==(const BrcClockCorrection& right) const
-      throw()
+      noexcept
    {
          // EngNav has no data
       return ((dataLoaded == right.dataLoaded) &&
@@ -161,7 +161,7 @@ namespace gpstk
    void BrcClockCorrection::loadData(const ObsID obsIDArg, const short PRNIDArg,
                                      const short fullweeknum,
                                      const long subframe1[10] )
-      throw(InvalidParameter)
+      noexcept(false)
    {
       double ficked[60];
 
@@ -218,13 +218,13 @@ namespace gpstk
    }
 
    CommonTime BrcClockCorrection::getEpochTime() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       return Toc;
    }
 
    double BrcClockCorrection::svClockBias(const CommonTime& t) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       double dtc,elaptc;
       elaptc = t - getEpochTime();
@@ -233,7 +233,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::svClockBiasM(const CommonTime& t) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       double ret = svClockBias(t);
       ret = ret*C_MPS;
@@ -241,7 +241,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::svClockDrift(const CommonTime& t) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       double drift,elaptc;
       elaptc = t - getEpochTime();
@@ -250,7 +250,7 @@ namespace gpstk
    }
 
    short BrcClockCorrection::getPRNID() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if(!dataLoaded)
       {
@@ -261,7 +261,7 @@ namespace gpstk
    }
 
    ObsID BrcClockCorrection::getObsID() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if(!dataLoaded)
       {
@@ -272,7 +272,7 @@ namespace gpstk
    }
 
    short BrcClockCorrection::getFullWeek()  const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -284,7 +284,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::getAccuracy(const CommonTime& t)  const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       double accuracy;
 
@@ -303,7 +303,7 @@ namespace gpstk
    }
 
    short BrcClockCorrection::getURAoc(const short& ndx) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -317,7 +317,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::getToc() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -329,7 +329,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::getAf0() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -340,7 +340,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::getAf1() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -351,7 +351,7 @@ namespace gpstk
    }
 
    double BrcClockCorrection::getAf2() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {

--- a/core/lib/GNSSEph/BrcClockCorrection.hpp
+++ b/core/lib/GNSSEph/BrcClockCorrection.hpp
@@ -75,7 +75,7 @@ namespace gpstk
    {
    public:
          /// Default constructor
-      BrcClockCorrection() throw();
+      BrcClockCorrection() noexcept;
 
 	 /// General purpose constructor
       BrcClockCorrection( const std::string satSysArg, const ObsID obsIDArg,
@@ -94,8 +94,8 @@ namespace gpstk
          /// Destructor
       virtual ~BrcClockCorrection() {}
 
-      bool operator==(const BrcClockCorrection& right) const throw();
-      bool operator!=(const BrcClockCorrection& right) const throw()
+      bool operator==(const BrcClockCorrection& right) const noexcept;
+      bool operator!=(const BrcClockCorrection& right) const noexcept
       { return !operator==(right); }
 
          /**
@@ -107,66 +107,66 @@ namespace gpstk
          /**
           * Returns the epoch time (time of clock) from this
           * ephemeris, correcting for half weeks and HOW time. */
-      CommonTime getEpochTime() const throw(gpstk::InvalidRequest);
+      CommonTime getEpochTime() const noexcept(false);
 
          /** This function returns the PRN ID of the SV. */
-      short getPRNID() const throw(gpstk::InvalidRequest);
+      short getPRNID() const noexcept(false);
 
          /** This function returns the OBS ID of the clock correction. */
-      ObsID getObsID() const throw(gpstk::InvalidRequest);
+      ObsID getObsID() const noexcept(false);
 
          /**
           * This function returns the value of the SV accuracy (m)
           * computed from the accuracy flag in the nav message. */
       double getAccuracy(const CommonTime& t) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
-      short getURAoc(const short& ndx) const throw(gpstk::InvalidRequest);
+      short getURAoc(const short& ndx) const noexcept(false);
 
          /** Returns SV health status. */
          //NB Determine if this function is needed, as it is never used
-         //bool isHealthy() const throw(gpstk::InvalidRequest);
+         //bool isHealthy() const noexcept(false);
 
          /**
           * This function return the GPS week number for the
           * orbit. This is the full GPS week (ie > 10 bits). */
-      short getFullWeek() const throw(gpstk::InvalidRequest);
+      short getFullWeek() const noexcept(false);
 
          /**
           * This function returns the clock epoch in GPS seconds of
           * week. */
-      double getToc() const throw(gpstk::InvalidRequest);
+      double getToc() const noexcept(false);
 
          /** This function returns the SV clock error in seconds. */
-      double getAf0() const throw(gpstk::InvalidRequest);
+      double getAf0() const noexcept(false);
 
          /**
           * This function returns the SV clock drift in
           * seconds/seconds. */
-      double getAf1() const throw(gpstk::InvalidRequest);
+      double getAf1() const noexcept(false);
 
          /**
           * This function returns the SV clock rate of change of the
           * drift in seconds/(seconds*seconds). */
-      double getAf2() const throw(gpstk::InvalidRequest);
+      double getAf2() const noexcept(false);
 
          /** Compute the satellite clock bias (sec) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svClockBias(const CommonTime& t) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Compute the satellite clock bias (meters) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svClockBiasM(const CommonTime& t) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Compute the satellite clock drift (sec/sec) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svClockDrift(const CommonTime& t) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** General purpose means to load data into object. */
       void loadData( const std::string satSysArg, const ObsID obsIDArg,
@@ -186,7 +186,7 @@ namespace gpstk
          /** Load data based on the GPS Legacy message. */
       void loadData( const ObsID obsIDArg, const short PRNID,
                      const short fullweeknum, const long subframe1[10] )
-         throw(InvalidParameter);
+         noexcept(false);
 
          /** Output the contents of this ephemeris to the given stream. */
       void dump(std::ostream& s = std::cout) const;

--- a/core/lib/GNSSEph/BrcKeplerOrbit.cpp
+++ b/core/lib/GNSSEph/BrcKeplerOrbit.cpp
@@ -48,7 +48,7 @@ namespace gpstk
    using namespace gpstk;
 
    BrcKeplerOrbit::BrcKeplerOrbit()
-      throw()
+      noexcept
    {
       dataLoaded = false;
 
@@ -99,7 +99,7 @@ namespace gpstk
    }
 
 
-   bool BrcKeplerOrbit::operator==(const BrcKeplerOrbit& right) const throw()
+   bool BrcKeplerOrbit::operator==(const BrcKeplerOrbit& right) const noexcept
    {
       return ((dataLoaded == right.dataLoaded) &&
               (satSys == right.satSys) &&
@@ -182,7 +182,7 @@ namespace gpstk
                                  const long subframe1[10],
                                  const long subframe2[10],
                                  const long subframe3[10])
-      throw(InvalidParameter)
+      noexcept(false)
    {
       double ficked[60];
 
@@ -281,7 +281,7 @@ namespace gpstk
    }
 
    bool BrcKeplerOrbit::isHealthy() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {   
@@ -292,7 +292,7 @@ namespace gpstk
    }
 
    bool BrcKeplerOrbit::withinFitInterval(const CommonTime ct) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {   
@@ -304,7 +304,7 @@ namespace gpstk
    }
 
    Xvt BrcKeplerOrbit::svXvt(const CommonTime& t) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       Xvt sv;
 
@@ -446,7 +446,7 @@ namespace gpstk
    }
 
    double BrcKeplerOrbit::svRelativity(const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       GPSEllipsoid ell;
       double twoPI  = 2.0e0 * PI;
@@ -472,13 +472,13 @@ namespace gpstk
    }
 
    CommonTime BrcKeplerOrbit::getOrbitEpoch() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       return Toe;
    }
    
    CommonTime BrcKeplerOrbit::getBeginningOfFitInterval() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {   
@@ -489,7 +489,7 @@ namespace gpstk
    }
 
    CommonTime BrcKeplerOrbit::getEndOfFitInterval() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {   
@@ -500,7 +500,7 @@ namespace gpstk
    }
 
    short BrcKeplerOrbit::getPRNID() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if(!dataLoaded)
       {
@@ -511,7 +511,7 @@ namespace gpstk
    }   
   
    ObsID BrcKeplerOrbit::getObsID() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if(!dataLoaded)
       {
@@ -522,7 +522,7 @@ namespace gpstk
    }
 
    short BrcKeplerOrbit::getFullWeek()  const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -534,7 +534,7 @@ namespace gpstk
    }   
   
    double BrcKeplerOrbit::getAccuracy()  const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -546,7 +546,7 @@ namespace gpstk
    }   
 
    void BrcKeplerOrbit::setAccuracy(const double& acc)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -557,7 +557,7 @@ namespace gpstk
    }
 
    short BrcKeplerOrbit::getURAoe() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -568,7 +568,7 @@ namespace gpstk
    }
          
    double BrcKeplerOrbit::getCus() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -579,7 +579,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getCrs() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -590,7 +590,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getCis() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -601,7 +601,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getCrc() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -612,7 +612,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getCuc() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -623,7 +623,7 @@ namespace gpstk
    }
   
    double BrcKeplerOrbit::getCic() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -634,7 +634,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getToe() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -646,7 +646,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getM0() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -657,7 +657,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getDn() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -668,7 +668,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getEcc() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -679,7 +679,7 @@ namespace gpstk
    }
       
    double BrcKeplerOrbit::getA() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -690,7 +690,7 @@ namespace gpstk
    }
 
    double BrcKeplerOrbit::getAhalf() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -701,7 +701,7 @@ namespace gpstk
    }
 
    double BrcKeplerOrbit::getAdot() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -712,7 +712,7 @@ namespace gpstk
    }
 
    double BrcKeplerOrbit::getDnDot() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -723,7 +723,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getOmega0() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -734,7 +734,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getI0() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -745,7 +745,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getW() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -756,7 +756,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getOmegaDot() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -767,7 +767,7 @@ namespace gpstk
    }
    
    double BrcKeplerOrbit::getIDot() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded)
       {
@@ -837,7 +837,7 @@ namespace gpstk
    }
 #pragma clang diagnostic pop
    void BrcKeplerOrbit::dump(ostream& s) const
-      throw()
+      noexcept
    {
       const ios::fmtflags oldFlags = s.flags();
       s.setf(ios::fixed, ios::floatfield);

--- a/core/lib/GNSSEph/BrcKeplerOrbit.hpp
+++ b/core/lib/GNSSEph/BrcKeplerOrbit.hpp
@@ -81,7 +81,7 @@ namespace gpstk
    public:
          /// Constructors
          /// Default constuctor
-      BrcKeplerOrbit( ) throw();
+      BrcKeplerOrbit( ) noexcept;
 
          /**
           * All constructors and loadData methods assume weeknumArg
@@ -118,8 +118,8 @@ namespace gpstk
          /// Destructor
       virtual ~BrcKeplerOrbit() {}
 
-      bool operator==(const BrcKeplerOrbit& right) const throw();
-      bool operator!=(const BrcKeplerOrbit& right) const throw()
+      bool operator==(const BrcKeplerOrbit& right) const noexcept;
+      bool operator!=(const BrcKeplerOrbit& right) const noexcept
       { return !(operator==(right)); }
 
          /// General purpose means to load data into object
@@ -145,145 +145,145 @@ namespace gpstk
                      const long subframe1[10],
                      const long subframe2[10],
                      const long subframe3[10] )
-         throw( InvalidParameter );
+         noexcept(false);
 
          /** 
           * Returns the epoch time (time of ephemeris) from this
           * ephemeris, correcting for half weeks and HOW time. */
-      CommonTime getOrbitEpoch() const throw(InvalidRequest);
+      CommonTime getOrbitEpoch() const noexcept(false);
 
          /** Returns the time at the beginning of the fit interval. */
-      CommonTime getBeginningOfFitInterval() const throw(InvalidRequest);
+      CommonTime getBeginningOfFitInterval() const noexcept(false);
 
          /** Returns the time at the end of the fit interval. */
-      CommonTime getEndOfFitInterval() const throw(InvalidRequest);
+      CommonTime getEndOfFitInterval() const noexcept(false);
 
          /** Return true if orbit data has been loaded */
       bool hasData( ) const;
 
          /** Return satellite system ID */
          //@note Determine if this function is needed, as it is never used
-         //std::string getSatSystem() const throw(gpstk::InvalidRequest);
+         //std::string getSatSystem() const noexcept(false);
 
          /** Return signal type associated with this orbit */
          //@note Determine if this function is needed, as it is never used
-         //std::string getSignal() const throw(gpstk::InvalidRequest);
+         //std::string getSignal() const noexcept(false);
 
          /** This function returns the PRN ID of the SV. */
-      short getPRNID() const throw(gpstk::InvalidRequest);
+      short getPRNID() const noexcept(false);
 
          /** This function returns the OBS ID of the orbit. */
-      ObsID getObsID() const throw(gpstk::InvalidRequest);
+      ObsID getObsID() const noexcept(false);
 
          /** This function returns the health status of the SV. */
-      bool isHealthy() const throw(gpstk::InvalidRequest);
+      bool isHealthy() const noexcept(false);
 
          /** Return true if fit interval is valid . */
       bool withinFitInterval(const CommonTime) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** This function return the GPS week number for the
           * orbit.  this is the full GPS week (ie > 10 bits). */
-      short getFullWeek() const throw(gpstk::InvalidRequest);
+      short getFullWeek() const noexcept(false);
       
          /** This function returns the value of the SV accuracy (m)
           * computed from the accuracy information contained in the
           * nav message */
-      double getAccuracy() const throw(gpstk::InvalidRequest);
+      double getAccuracy() const noexcept(false);
 
-      void setAccuracy(const double& acc) throw(gpstk::InvalidRequest);
+      void setAccuracy(const double& acc) noexcept(false);
    
-      short getURAoe() const throw(gpstk::InvalidRequest);
+      short getURAoe() const noexcept(false);
 
          /** This function returns the value of the sine latitude
           * harmonic perturbation in radians. */
-      double getCus() const throw(gpstk::InvalidRequest);
+      double getCus() const noexcept(false);
       
          /** This function returns the value of the sine radius
           * harmonic perturbation in meters. */
-      double getCrs() const throw(gpstk::InvalidRequest);
+      double getCrs() const noexcept(false);
       
          /** This function returns the value of the sine inclination
           * harmonic perturbation in radians. */
-      double getCis() const throw(gpstk::InvalidRequest);
+      double getCis() const noexcept(false);
       
          /** This function returns the value of the cosine radius
           * harmonic perturbation in meters. */
-      double getCrc() const throw(gpstk::InvalidRequest);
+      double getCrc() const noexcept(false);
       
          /** This function returns the value of the cosine latitude
           * harmonic perturbation in radians. */
-      double getCuc() const throw(gpstk::InvalidRequest);
+      double getCuc() const noexcept(false);
       
          /** This function returns the value of the cosine inclination
           * harmonic perturbation in radians. */
-      double getCic() const throw(gpstk::InvalidRequest);
+      double getCic() const noexcept(false);
       
          /** This function returns the value of the time of orbit
           * in GPS seconds of week. */
-      double getToe() const throw(gpstk::InvalidRequest);
+      double getToe() const noexcept(false);
       
          /** This function returns the value of the mean anomaly in
           * radians. */
-      double getM0() const throw(gpstk::InvalidRequest);
+      double getM0() const noexcept(false);
       
          /** This function returns the value of the correction to the
           * mean motion in radians/second. */
-      double getDn() const throw(gpstk::InvalidRequest);
+      double getDn() const noexcept(false);
 
          /** This function returns the value of the rate correction to the
           * mean motion in radians/second**2. */
-      double getDnDot() const throw(gpstk::InvalidRequest);
+      double getDnDot() const noexcept(false);
       
          /** This function returns the value of the eccentricity. */
-      double getEcc() const throw(gpstk::InvalidRequest);
+      double getEcc() const noexcept(false);
       
          /** This function returns the value of the 
           * semi-major axis in meters. */
-      double getA() const throw(gpstk::InvalidRequest);
+      double getA() const noexcept(false);
       
          /** This function returns the value of the 
           * square root of the semi-major axis in meters**.5. */
-      double getAhalf() const throw(gpstk::InvalidRequest);
+      double getAhalf() const noexcept(false);
 
          /** This function returns the value of the rate of the
           * semi-major axis in meters/sec. */
-      double getAdot() const throw(gpstk::InvalidRequest);
+      double getAdot() const noexcept(false);
    
          /** This function returns the value of the right ascension of
           * the ascending node in radians. */
-      double getOmega0() const throw(gpstk::InvalidRequest);
+      double getOmega0() const noexcept(false);
       
          /** This function returns the value of the inclination in
           * radians. */
-      double getI0() const throw(gpstk::InvalidRequest);
+      double getI0() const noexcept(false);
       
          /** This function returns the value of the argument of
           * perigee in radians. */
-      double getW() const throw(gpstk::InvalidRequest);
+      double getW() const noexcept(false);
       
          /** This function returns the value of the rate of the right
           * ascension of the ascending node in radians/second. */
-      double getOmegaDot() const throw(gpstk::InvalidRequest);
+      double getOmegaDot() const noexcept(false);
       
          /** This function returns the value of the rate of the
           * inclination in radians/second. */
-      double getIDot() const throw(gpstk::InvalidRequest);
+      double getIDot() const noexcept(false);
       
          /** Compute satellite position at the given time
           * using this orbit data.
           * @throw InvalidRequest if a required subframe has not been stored.
           */
-      Xvt svXvt(const CommonTime& t) const throw(gpstk::InvalidRequest);
+      Xvt svXvt(const CommonTime& t) const noexcept(false);
 
          /** Compute satellite relativity correction (sec) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svRelativity(const CommonTime& t) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
       
          /** Output the contents of this orbit data to the given stream. */
-      void dump(std::ostream& s = std::cout) const throw();
+      void dump(std::ostream& s = std::cout) const noexcept;
 
    protected:
          /// @name Overhead information

--- a/core/lib/GNSSEph/ClockSatStore.cpp
+++ b/core/lib/GNSSEph/ClockSatStore.cpp
@@ -46,7 +46,7 @@ using namespace std;
 namespace gpstk
 {
    // Output stream operator is used by dump() in TabularSatStore
-   ostream& operator<<(ostream& os, const ClockRecord& rec) throw()
+   ostream& operator<<(ostream& os, const ClockRecord& rec) noexcept
    {
       os << scientific << setprecision(12) << setw(19) << rec.bias
          << " " << setw(19) << rec.sig_bias
@@ -68,7 +68,7 @@ namespace gpstk
    //  b) checkDataGap is true and there is a data gap
    //  c) checkInterval is true and the interval is larger than maxInterval
    ClockRecord ClockSatStore::getValue(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -199,7 +199,7 @@ namespace gpstk
    //  b) checkDataGap is true and there is a data gap
    //  c) checkInterval is true and the interval is larger than maxInterval
    double ClockSatStore::getClockBias(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -248,7 +248,7 @@ namespace gpstk
    //  c) checkInterval is true and the interval is larger than maxInterval
    //  d) there is no drift data in the store
    double ClockSatStore::getClockDrift(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -314,7 +314,7 @@ namespace gpstk
    // Add a ClockRecord to the store.
    void ClockSatStore::addClockRecord(const SatID& sat, const CommonTime& ttag,
                                       const ClockRecord& rec)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -346,7 +346,7 @@ namespace gpstk
    // Add clock bias (only) data to the store
    void ClockSatStore::addClockBias(const SatID& sat, const CommonTime& ttag,
                                     const double& bias, const double& sig)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -374,7 +374,7 @@ namespace gpstk
    // Add clock drift (only) data to the store
    void ClockSatStore::addClockDrift(const SatID& sat, const CommonTime& ttag,
                                     const double& drift, const double& sig)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -404,7 +404,7 @@ namespace gpstk
    // Add clock acceleration (only) data to the store
    void ClockSatStore::addClockAcceleration(const SatID& sat, const CommonTime& ttag,
                                     const double& accel, const double& sig)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());

--- a/core/lib/GNSSEph/ClockSatStore.hpp
+++ b/core/lib/GNSSEph/ClockSatStore.hpp
@@ -68,7 +68,7 @@ namespace gpstk
    } ClockRecord;
 
       /// Output stream operator is used by dump() in TabularSatStore
-   std::ostream& operator<<(std::ostream& os, const ClockRecord& rec) throw();
+   std::ostream& operator<<(std::ostream& os, const ClockRecord& rec) noexcept;
 
       // This is a helper for SWIG processing - it needs a template
       // instation of the base type of ClockSatStore before it is
@@ -123,7 +123,7 @@ namespace gpstk
    public:
 
          /// Default constructor
-      ClockSatStore() throw() : haveClockAccel(false),
+      ClockSatStore() noexcept : haveClockAccel(false),
          interpType(2), Nhalf(5),
          rejectBadClockFlag(true)
       {
@@ -136,7 +136,7 @@ namespace gpstk
          /// Destructor
       virtual ~ClockSatStore() {};
 
-      bool hasClockAccel() const throw() { return haveClockAccel; }
+      bool hasClockAccel() const noexcept { return haveClockAccel; }
 
          /** Return value for the given satellite at the given time
           * (usually via interpolation of the data table). This
@@ -152,7 +152,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       virtual ClockRecord getValue(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the clock bias for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -166,7 +166,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       double getClockBias(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the clock drift for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -181,7 +181,7 @@ namespace gpstk
           *     maxInterval
           *  d) there is no drift data in the store */
       double getClockDrift(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Dump information about the object to an ostream.
           * @param[in] os ostream to receive the output; defaults to std::cout
@@ -191,7 +191,7 @@ namespace gpstk
           *           gap and interval flags and values, and file information
           *    1: number of data/sat
           *    2: above plus all the data tables */
-      virtual void dump(std::ostream& os = std::cout, int detail = 0) const throw()
+      virtual void dump(std::ostream& os = std::cout, int detail = 0) const noexcept
       {
          os << "Dump of ClockSatStore(" << detail << "):\n";
          os << " This store "
@@ -217,30 +217,30 @@ namespace gpstk
           *   different). */
       void addClockRecord(const SatID& sat, const CommonTime& ttag,
                           const ClockRecord& rec)
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Add clock bias data (only) to the store
       void addClockBias(const SatID& sat, const CommonTime& ttag,
                         const double& bias, const double& sig=0.0)
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Add clock drift data (only) to the store
       void addClockDrift(const SatID& sat, const CommonTime& ttag,
                          const double& drift, const double& sig=0.0)
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Add clock acceleration data (only) to the store
       void addClockAcceleration(const SatID& sat, const CommonTime& ttag,
                                 const double& accel, const double& sig=0.0)
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Get current interpolation order.
-      unsigned int getInterpolationOrder(void) throw()
+      unsigned int getInterpolationOrder(void) noexcept
       { return interpOrder; }
 
          /** Set the interpolation order; this routine forces the
           * order to be even. */
-      void setInterpolationOrder(unsigned int order) throw()
+      void setInterpolationOrder(unsigned int order) noexcept
       {
          if(interpType == 2) Nhalf = (order+1)/2;
          else                Nhalf = 1;
@@ -253,11 +253,11 @@ namespace gpstk
       { rejectBadClockFlag = flag; }
 
          /// Set the type of interpolation to Lagrange (default)
-      void setLagrangeInterp(void) throw()
+      void setLagrangeInterp(void) noexcept
       { interpType = 2; setInterpolationOrder(10); }
 
          /// Set the type of interpolation to linear. Note that
-      void setLinearInterp(void) throw()
+      void setLinearInterp(void) noexcept
       { interpType = 1; setInterpolationOrder(2); }
 
    }; // end class ClockSatStore

--- a/core/lib/GNSSEph/EngAlmanac.cpp
+++ b/core/lib/GNSSEph/EngAlmanac.cpp
@@ -59,7 +59,7 @@ if (itty == almPRN.end()) \
 namespace gpstk
 {
    EngAlmanac :: EngAlmanac()
-      throw()
+      noexcept
    {
       for (int n = 0; n < 4; n++)
       {
@@ -81,7 +81,7 @@ namespace gpstk
 
    bool EngAlmanac::addSubframe(const long subframe[10],
                                 const int gpsWeek)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       uint32_t tinput[10];
       for (int n=0;n<10;++n)
@@ -91,7 +91,7 @@ namespace gpstk
 
    bool EngAlmanac::addSubframe(const uint32_t subframe[10],
                                 const short gpsWeek)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       double ficked[60];
 
@@ -196,7 +196,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getEcc(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -206,7 +206,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getIOffset(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -216,7 +216,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getOmegadot(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
 
       AlmOrbits::const_iterator i = almPRN.find(sat);
@@ -227,7 +227,7 @@ namespace gpstk
    }
 
    short EngAlmanac::get6bitHealth(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       SVBitsMap::const_iterator i = health.find(sat.id);
       if (i == health.end())
@@ -241,7 +241,7 @@ namespace gpstk
    }
 
    short EngAlmanac::getSVHealth(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -251,7 +251,7 @@ namespace gpstk
    }
 
    short EngAlmanac::getSVConfig(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       SVBitsMap::const_iterator i = SV_config.find(sat.id);
       if (i == SV_config.end())
@@ -265,7 +265,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getAhalf(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -275,7 +275,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getA(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -285,7 +285,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getOmega0(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
 
       AlmOrbits::const_iterator i = almPRN.find(sat);
@@ -296,7 +296,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getW(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -306,7 +306,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getM0(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -316,7 +316,7 @@ namespace gpstk
    }
 
    double EngAlmanac::getAf0(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -327,7 +327,7 @@ namespace gpstk
 
 
    double EngAlmanac::getAf1(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -337,13 +337,13 @@ namespace gpstk
    }
 
 
-   double EngAlmanac::getToa() const throw()
+   double EngAlmanac::getToa() const noexcept
    {
       return static_cast<double>( t_oa );
    }
 
    double EngAlmanac::getToa(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -354,7 +354,7 @@ namespace gpstk
 
 
    double EngAlmanac::getXmitTime(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -365,7 +365,7 @@ namespace gpstk
 
 
    short EngAlmanac::getFullWeek(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -374,7 +374,7 @@ namespace gpstk
    }
 
    void EngAlmanac::getIon(double a[4], double b[4]) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!haveUTC)
       {
@@ -392,7 +392,7 @@ namespace gpstk
    void EngAlmanac::getUTC(double& a0, double& a1, double& deltaTLS,
                            long& tot, int& WNt, int& WNLSF,
                            int& DN, double& deltaTLSF) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!haveUTC)
       {
@@ -410,13 +410,13 @@ namespace gpstk
       deltaTLSF = dt_lsf;
    }
 
-   short EngAlmanac::getAlmWeek() const throw()
+   short EngAlmanac::getAlmWeek() const noexcept
    {
       return alm_wk;
    }
 
    AlmOrbit EngAlmanac::getAlmOrbElem(SatID sat) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -426,7 +426,7 @@ namespace gpstk
    }
 
    Xvt EngAlmanac::svXvt(SatID sat, const CommonTime& t) const
-      throw(SVNotPresentException)
+      noexcept(false)
    {
       AlmOrbits::const_iterator i = almPRN.find(sat);
       CHECK_SV_HERE(i, sat);
@@ -435,7 +435,7 @@ namespace gpstk
       return (*i).second.svXvt(t);
    }
 
-   bool EngAlmanac::isData(SatID sat) const throw()
+   bool EngAlmanac::isData(SatID sat) const noexcept
    {
       return (almPRN.find(sat) != almPRN.end());
    }

--- a/core/lib/GNSSEph/EngAlmanac.hpp
+++ b/core/lib/GNSSEph/EngAlmanac.hpp
@@ -74,7 +74,7 @@ namespace gpstk
       typedef std::map<short, unsigned char, std::less<short> > SVBitsMap;
 
          /// Default constructor, blank almanac.
-      EngAlmanac() throw();
+      EngAlmanac() noexcept;
 
          /// Destructor
       virtual ~EngAlmanac() {}
@@ -88,7 +88,7 @@ namespace gpstk
           * @throw InvalidParameter if subframe is valid but not subframe 4-5.
           */
       bool addSubframe(const long subframe[10], const int gpsWeek)
-         throw(gpstk::InvalidParameter);
+         noexcept(false);
 
          /**
           * Store a subframe in this object.
@@ -99,26 +99,26 @@ namespace gpstk
           * @throw InvalidParameter if subframe is valid but not subframe 4-5.
           */
       bool addSubframe(const uint32_t subframe[10], const short gpsWeek)
-         throw(gpstk::InvalidParameter);
+         noexcept(false);
 
          /** This function returns true if data is available for a given
           * PRN.  This data is accessed by the below accesser methods
           */
-      bool isData(SatID sat) const throw();
+      bool isData(SatID sat) const noexcept;
 
          /** This function returns the value of the eccentricity for
           * the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getEcc(SatID sat) const throw(SVNotPresentException);
+      double getEcc(SatID sat) const noexcept(false);
 
          /** This function returns the value of the offset of the
           * inclination from 54 degrees in radians for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getIOffset(SatID sat) const throw(SVNotPresentException);
+      double getIOffset(SatID sat) const noexcept(false);
 
          /** This function returns the value of the rate of the right
           * ascension of the ascending node in radians/second for the
@@ -126,7 +126,7 @@ namespace gpstk
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getOmegadot(SatID sat) const throw(SVNotPresentException);
+      double getOmegadot(SatID sat) const noexcept(false);
 
          /** This function returns the value of the health of the given
           * PRN from the general pages in the almanac.  It return the
@@ -134,7 +134,7 @@ namespace gpstk
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      short get6bitHealth(SatID sat) const throw(SVNotPresentException);
+      short get6bitHealth(SatID sat) const noexcept(false);
 
          /** This function returns the value of the health of the given
           * PRN from the PRN specific page which might not be present.
@@ -142,7 +142,7 @@ namespace gpstk
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      short getSVHealth(SatID sat) const throw(SVNotPresentException);
+      short getSVHealth(SatID sat) const noexcept(false);
 
 
          /** This function returns the four-bit A/S-flag and configuration
@@ -150,7 +150,7 @@ namespace gpstk
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      short getSVConfig(SatID sat) const throw(SVNotPresentException);
+      short getSVConfig(SatID sat) const noexcept(false);
 
          /** This function returns the value of the square root of the
           * semi-major axis in square root of meters for the given
@@ -158,84 +158,84 @@ namespace gpstk
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getAhalf(SatID sat) const throw(SVNotPresentException);
+      double getAhalf(SatID sat) const noexcept(false);
 
          /** This function returns the value of the semi-major axis in
           * meters for the specified PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getA(SatID sat) const throw(SVNotPresentException);
+      double getA(SatID sat) const noexcept(false);
 
          /** This function returns the value of the right ascension of
           * the ascending node in radians for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getOmega0(SatID sat) const throw(SVNotPresentException);
+      double getOmega0(SatID sat) const noexcept(false);
 
          /** This function returns the value of the argument of perigee
           * in radians for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getW(SatID sat) const throw(SVNotPresentException);
+      double getW(SatID sat) const noexcept(false);
 
          /** This function returns the value of the mean anomaly in
           * radians for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getM0(SatID sat) const throw(SVNotPresentException);
+      double getM0(SatID sat) const noexcept(false);
 
          /** This function returns the SV clock error in seconds for
           * the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getAf0(SatID sat) const throw(SVNotPresentException);
+      double getAf0(SatID sat) const noexcept(false);
 
          /** This function returns the SV clock drift in
           * seconds/seconds for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getAf1(SatID sat) const throw(SVNotPresentException);
+      double getAf1(SatID sat) const noexcept(false);
 
          /** This function returns the value of the time of the almanac
           * (from page 51) in GPS seconds of week.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getToa() const throw();
+      double getToa() const noexcept;
 
          /** This function returns the value of the time of the almanac
           * in GPS seconds of week for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getToa(SatID sat) const throw(SVNotPresentException);
+      double getToa(SatID sat) const noexcept(false);
 
          /** This function returns the value of the transmit time for
           * this almanac data in seconds of week for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      double getXmitTime(SatID sat) const throw(SVNotPresentException);
+      double getXmitTime(SatID sat) const noexcept(false);
 
          /** This function returns the value of the week of the page
           * transmission for the given PRN.
           * @throw SVNotPresentException if almanac page for the given
           * PRN isn't present.
           */
-      short getFullWeek(SatID sat) const throw(SVNotPresentException);
+      short getFullWeek(SatID sat) const noexcept(false);
 
          /**
           * Get the ionospheric parameters.
           * @throw InvalidRequest if the almanac page isn't present
           */
       void getIon(double a[4], double b[4]) const
-         throw(InvalidRequest);
+         noexcept(false);
 
          /**
           * Get the UTC offset parameters.
@@ -243,7 +243,7 @@ namespace gpstk
           */
       void getUTC(double& a0, double& a1, double& deltaTLS, long& tot,
                   int& WNt, int& WNLSF, int& DN, double& deltaTLSF) const
-         throw(InvalidRequest);
+         noexcept(false);
 
          /** This function gets the week number for the almanac stored
           * in this object.  It is replaced when an almanac is
@@ -253,7 +253,7 @@ namespace gpstk
           * data to the almanac.  This is a full GPS week number (ie >
           * 10 bits)
           */
-      short getAlmWeek() const throw();
+      short getAlmWeek() const noexcept;
 
          /** This function returns an object containing all of the
           * almanac orbit elements for the given PRN.
@@ -261,7 +261,7 @@ namespace gpstk
           * PRN isn't present.
           */
       AlmOrbit getAlmOrbElem(SatID sat) const
-         throw(SVNotPresentException);
+         noexcept(false);
 
          /** This function returns an object containing all of the
           * almanac orbit elements.
@@ -276,11 +276,11 @@ namespace gpstk
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       Xvt svXvt(SatID sat, const CommonTime& t) const
-         throw(SVNotPresentException);
+         noexcept(false);
 
          /// \deprecated use the SatID version
       Xvt svXvt(short prn, const CommonTime& t) const
-         throw(SVNotPresentException)
+         noexcept(false)
       { SatID sat(prn,SatID::systemGPS); return svXvt(sat,t); }
 
       void dump(std::ostream& s = std::cout, bool checkFlag=true) const;
@@ -291,7 +291,7 @@ namespace gpstk
          /** This function is used to make sure data is present before
           * accessing it.
           */
-      void checkSVHere(SatID sat) const throw(SVNotPresentException);
+      void checkSVHere(SatID sat) const noexcept(false);
 
 
          /** @name Ionosphere Parameters */

--- a/core/lib/GNSSEph/EngEphemeris.cpp
+++ b/core/lib/GNSSEph/EngEphemeris.cpp
@@ -58,7 +58,7 @@ namespace gpstk
    using namespace std;
 
    EngEphemeris::EngEphemeris()
-      throw()
+      noexcept
    {
       haveSubframe[0] = haveSubframe[1] = haveSubframe[2] = false;
 
@@ -96,7 +96,7 @@ namespace gpstk
    }
 
 
-   bool EngEphemeris::operator==(const gpstk::EngEphemeris& right) const throw()
+   bool EngEphemeris::operator==(const gpstk::EngEphemeris& right) const noexcept
    {
          // ignored as not important for eng eph comparison
          //haveSubframe
@@ -144,7 +144,7 @@ namespace gpstk
    bool EngEphemeris::addSubframe(const uint32_t subframe[10],
                                   const int gpsWeek, const short PRN,
                                   const short track)
-      throw( InvalidParameter )
+      noexcept(false)
    {
          // Determine the subframe number
       uint32_t SFword2 = (uint32_t) subframe[1];
@@ -181,7 +181,7 @@ namespace gpstk
                                           const int  gpsWeek,
                                           const short PRN,
                                           const short track)
-      throw( InvalidParameter )
+      noexcept(false)
    {
       uint32_t paddedSF[10];
       short PRNArg;
@@ -375,7 +375,7 @@ namespace gpstk
    }
 
    bool EngEphemeris :: isValid() const
-      throw()
+      noexcept
    {
       try
       {
@@ -394,7 +394,7 @@ namespace gpstk
    }
 
    bool EngEphemeris::isData(short subframe) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if ((subframe < 1) || (subframe > 3))
       {
@@ -416,7 +416,7 @@ namespace gpstk
    }
 
    void EngEphemeris::setAccuracy(const double& acc)
-      throw( InvalidParameter )
+      noexcept(false)
    {
       if( acc < 0 )
       {
@@ -428,7 +428,7 @@ namespace gpstk
    }
 
    short EngEphemeris :: getFitInterval() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       return getFitInterval(getIODC(), getFitInt());
    }
@@ -438,7 +438,7 @@ namespace gpstk
        * Need update for Block IIR and IIF
        */
    short EngEphemeris :: getFitInterval(short iodc, short fiti)
-      throw(InvalidRequest)
+      noexcept(false)
    {
          /* check the IODC */
       if (iodc < 0 || iodc > 1023)
@@ -527,7 +527,7 @@ namespace gpstk
 
 
    Xvt EngEphemeris::svXvt(const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       Xvt sv;
 
@@ -545,25 +545,25 @@ namespace gpstk
    }
 
    double EngEphemeris::svRelativity(const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       return orbit.svRelativity(t);
    }
 
    double EngEphemeris::svClockBias(const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       return bcClock.svClockBias(t);
    }
 
    double EngEphemeris::svClockDrift(const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       return bcClock.svClockDrift(t);
    }
 
    unsigned EngEphemeris::getTLMMessage(short subframe) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[subframe-1])
       {
@@ -575,7 +575,7 @@ namespace gpstk
    }
 
    CommonTime EngEphemeris::getTransmitTime() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       CommonTime toReturn;
       try
@@ -596,19 +596,19 @@ namespace gpstk
    }
 
    CommonTime EngEphemeris::getEpochTime() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       return bcClock.getEpochTime();
    }
 
    CommonTime EngEphemeris::getEphemerisEpoch() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       return orbit.getOrbitEpoch();
    }
 
    BrcKeplerOrbit EngEphemeris::getOrbit() const
-      throw(InvalidRequest )
+      noexcept(false)
    {
       if(!orbit.hasData())
       {
@@ -619,7 +619,7 @@ namespace gpstk
    }
 
    BrcClockCorrection EngEphemeris::getClock() const
-      throw(InvalidRequest )
+      noexcept(false)
    {
       if(!bcClock.hasData())
       {
@@ -631,7 +631,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getPRNID() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if(!haveSubframe[0])
       {
@@ -642,7 +642,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getTracker() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if(!haveSubframe[0])
       {
@@ -653,7 +653,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getHOWTime(short subframe) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[subframe-1])
       {
@@ -669,7 +669,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getASAlert(short subframe)  const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[subframe-1])
       {
@@ -681,7 +681,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getFullWeek()  const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -692,7 +692,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getCodeFlags()  const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -703,7 +703,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getAccuracy()  const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -714,7 +714,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getAccFlag()  const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -725,7 +725,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getHealth() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -736,7 +736,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getL2Pdata() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -747,7 +747,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getIODC() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -758,7 +758,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getIODE() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -769,7 +769,7 @@ namespace gpstk
    }
 
    long EngEphemeris::getAODO() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -780,7 +780,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getToc() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -791,7 +791,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getAf0() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -802,7 +802,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getAf1() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -813,7 +813,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getAf2() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -824,7 +824,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getTgd() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[0])
       {
@@ -835,7 +835,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getCus() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -846,7 +846,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getCrs() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -857,7 +857,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getCis() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -868,7 +868,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getCrc() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -879,7 +879,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getCuc() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -890,7 +890,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getCic() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -901,7 +901,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getToe() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -912,7 +912,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getM0() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -923,7 +923,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getDn() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -934,7 +934,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getEcc() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -945,7 +945,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getAhalf() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -956,7 +956,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getA() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -967,7 +967,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getOmega0() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -978,7 +978,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getI0() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -989,7 +989,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getW() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -1000,7 +1000,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getOmegaDot() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -1011,7 +1011,7 @@ namespace gpstk
    }
 
    double EngEphemeris::getIDot() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[2])
       {
@@ -1022,7 +1022,7 @@ namespace gpstk
    }
 
    short EngEphemeris::getFitInt() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!haveSubframe[1])
       {
@@ -1033,7 +1033,7 @@ namespace gpstk
    }
 
    long EngEphemeris::getTot() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if(!haveSubframe[0])
       {
@@ -1081,7 +1081,7 @@ namespace gpstk
       const short fitInt, const double cic, const double Omega0,
       const double cis, const double I0, const double crc,
       const double W, const double OmegaDot, const double IDot )
-   throw( InvalidRequest )
+   noexcept(false)
    {
       PRNID = prn;
       tracker = Tracker;
@@ -1163,7 +1163,7 @@ namespace gpstk
                                        short l2pdata, double tgd, double toc,
                                        double Af2, double Af1, double Af0,
                                        short Tracker, short prn )
-      throw( InvalidRequest )
+      noexcept(false)
    {
       tlm_message[0] = tlm;
       HOWtime[0] = static_cast<long>( how );
@@ -1216,7 +1216,7 @@ namespace gpstk
                                        double m0, double cuc, double Ecc,
                                        double cus, double ahalf, double toe,
                                        short fitInt )
-      throw( InvalidRequest )
+      noexcept(false)
    {
       tlm_message[1] = tlm;
       HOWtime[1] = static_cast<long>( how );
@@ -1302,7 +1302,7 @@ namespace gpstk
                                        double cic, double Omega0, double cis,
                                        double I0, double crc, double W,
                                        double OmegaDot, double IDot )
-      throw( InvalidRequest )
+      noexcept(false)
    {
       tlm_message[2] = tlm;
       HOWtime[2] = static_cast<long>( how );
@@ -1449,7 +1449,7 @@ namespace gpstk
          << setfill(' ');
    }
    void EngEphemeris :: dumpTerse(ostream& s) const
-      throw(InvalidRequest )
+      noexcept(false)
    {
 
          // Check if the subframes have been loaded before attempting
@@ -1490,7 +1490,7 @@ namespace gpstk
 
 
    void EngEphemeris :: dump(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
 
 

--- a/core/lib/GNSSEph/EngEphemeris.hpp
+++ b/core/lib/GNSSEph/EngEphemeris.hpp
@@ -86,13 +86,13 @@ namespace gpstk
    public:
          /// Default constructor
       EngEphemeris()
-      throw();
+      noexcept;
 
          /// Destructor
       virtual ~EngEphemeris() {}
 
-      bool operator==(const EngEphemeris& right) const throw();
-      bool operator!=(const EngEphemeris& right) const throw()
+      bool operator==(const EngEphemeris& right) const noexcept;
+      bool operator!=(const EngEphemeris& right) const noexcept
       { return !(operator==(right)); }
 
          /**
@@ -109,7 +109,7 @@ namespace gpstk
                        const int   gpsWeek,
                        const short PRN,
                        const short track)
-         throw( gpstk::InvalidParameter );
+         noexcept(false);
 
          /**
           * Store a subframe in this object.  This method is provided in
@@ -129,7 +129,7 @@ namespace gpstk
                                const int   gpsWeek,
                                const short PRN,
                                const short track)
-         throw( gpstk::InvalidParameter );
+         noexcept(false);
 
          /**
           * Store a subframe in this object.  This method is provided in
@@ -169,7 +169,7 @@ namespace gpstk
           * in the IS-GPS-200.
           * @return true if all values are within their effective range.
           */
-      bool isValid() const throw();
+      bool isValid() const noexcept;
 
          /**
           * Query presence of subframe in this object.
@@ -179,7 +179,7 @@ namespace gpstk
           *   ephemeris subframe number.
           */
       bool isData(short subframe) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /**
           * Return whether the ephemeris contains a complete data set,
@@ -205,7 +205,7 @@ namespace gpstk
           * @throw InvalidParameter if the given accuracy value is invalid.
           */
       void setAccuracy(const double& acc)
-         throw( gpstk::InvalidParameter );
+         noexcept(false);
 
          /**
           * This computes and returns the fit interval for the
@@ -218,7 +218,7 @@ namespace gpstk
           * @throw InvalidRequest if data is missing.
           */
       short getFitInterval() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /**
           * Static version of the above.
@@ -228,255 +228,255 @@ namespace gpstk
           * @throw InvalidRequest if data is missing.
           */
       static short getFitInterval(short iodc, short fiti)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Compute satellite position & velocity at the given time
           * using this ephemeris.
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       Xvt svXvt(const CommonTime& t) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
 
          /// Return 0x8b, the upper 5 bits of the 22-bit TLM word.
          // kinda pointless, huh?
       unsigned char getTLMPreamble() const
-         throw()
+         noexcept
       { return 0x8b; }
 
          /// Return the lower 16 bits of the TLM word for the given subframe.
       unsigned getTLMMessage(short subframe) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /// Extracts the epoch time from this ephemeris, correcting
          /// for half weeks and HOW time
       CommonTime getEphemerisEpoch() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /// Extracts the epoch time (time of clock) from this
          /// ephemeris, correcting for half weeks and HOW time
       CommonTime getEpochTime() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /// Extracts the transmit time from the ephemeris using the Tot
       CommonTime getTransmitTime() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /// used for template functions
       CommonTime getTimestamp() const
-         throw()
+         noexcept
       { return getEpochTime(); }
 
          /** This functions returns the GNSS type (satellite system code) */
       std::string getSatSys() const
-         throw()
+         noexcept
       { return satSys; }
 
          /** This function returns the PRN ID of the SV. */
       short getPRNID() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the tracker number. */
       short getTracker() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the time of the HOW in subframe
           * 1 or 2 or 3 in seconds of week. */
       double getHOWTime(short subframe) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the A-S alert flag for either
           * subframe 1 or 2 or 3. */
       short getASAlert(short subframe) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the GPS week number contained in
           * subframe 1.  this is the full GPS week (ie > 10 bits). */
       short getFullWeek() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the values of the L2 codes. */
       short getCodeFlags() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the SV accuracy (m)
           * computed from the accuracy flag in the nav message, or
           * as set by the setAccuracy() method. */
       double getAccuracy() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the flag based on the SV accuracy
           * flag as it appears in the nav message. */
       short getAccFlag() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the SV health flag. */
       short getHealth() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the L2 P-code data
           * flag. */
       short getL2Pdata() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the IODC for the given PRN. */
       short getIODC() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function return the IODE for the ephemeris. */
       short getIODE() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function return the AODO for the ephemeris. */
       long getAODO() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the clock epoch in GPS seconds of
           * week. */
       double getToc() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the SV clock error in seconds. */
       double getAf0() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the SV clock drift in
           * seconds/seconds. */
       double getAf1() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the SV clock rate of change of the
           * drift in seconds/(seconds*seconds). */
       double getAf2() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the group delay
           * differential in seconds. */
       double getTgd() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the sine latitude
           * harmonic perturbation in radians. */
       double getCus() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the sine radius
           * harmonic perturbation in meters. */
       double getCrs() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the sine inclination
           * harmonic perturbation in radians. */
       double getCis() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the cosine radius
           * harmonic perturbation in meters. */
       double getCrc() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the cosine latitude
           * harmonic perturbation in radians. */
       double getCuc() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the cosine inclination
           * harmonic perturbation in radians. */
       double getCic() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the time of ephemeris
           * in GPS seconds of week. */
       double getToe() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the mean anomaly in
           * radians. */
       double getM0() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the correction to the
           * mean motion in radians/second. */
       double getDn() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the eccentricity. */
       double getEcc() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the square root of the
           * semi-major axis in square root of meters. */
       double getAhalf() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the semi-major axis in
           * meters. */
       double getA() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the right ascension of
           * the ascending node in radians. */
       double getOmega0() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the inclination in
           * radians. */
       double getI0() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the argument of
           * perigee in radians. */
       double getW() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the rate of the right
           * ascension of the ascending node in radians/second. */
       double getOmegaDot() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the rate of the
           * inclination in radians/second. */
       double getIDot() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** Compute satellite relativity correction (sec) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svRelativity(const CommonTime& t) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** Compute the satellite clock bias (sec) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svClockBias(const CommonTime& t) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** Compute the satellite clock drift (sec/sec) at the given time
           * @throw InvalidRequest if a required subframe has not been stored.
           */
       double svClockDrift(const CommonTime& t) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the fit interval
           * flag. */
       short getFitInt() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** This function returns the value of the ephemeris key that
           * is used to sort the ephemerides when they are stored in
           * the bcetable. */
          /** @todo Determine if this function is needed, as it is never used */
          //double getEphkey() const
-         //   throw( gpstk::InvalidRequest );
+         //   noexcept(false);
 
          /** This function returnst the value of the Time of Transmit.
           * Basically just the earliest of the HOWs. */
       long getTot() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
-      BrcKeplerOrbit getOrbit() const throw(gpstk::InvalidRequest);
+      BrcKeplerOrbit getOrbit() const noexcept(false);
 
-      BrcClockCorrection getClock() const throw(gpstk::InvalidRequest);
+      BrcClockCorrection getClock() const noexcept(false);
 
          /** Set the values contained in SubFrame 1,2 and 3.
           *
@@ -549,34 +549,34 @@ namespace gpstk
                               const double cis, const double I0,
                               const double crc, const double W,
                               const double OmegaDot, const double IDot )
-      throw( InvalidRequest );
+      noexcept(false);
 
       EngEphemeris& setSF1( unsigned tlm, double how, short asalert,
                             short fullweek, short cflags, short acc,
                             short svhealth, short iodc,
                             short l2pdata, double tgd, double toc, double Af2,
                             double Af1, double Af0, short Tracker, short prn )
-         throw( InvalidRequest );
+         noexcept(false);
 
       EngEphemeris& setSF2( unsigned tlm, double how, short asalert,
                             short iode, double crs, double Dn, double m0,
                             double cuc, double Ecc, double cus, double ahalf,
                             double toe, short fitInt )
-         throw( InvalidRequest );
+         noexcept(false);
 
       EngEphemeris& setSF3( unsigned tlm, double how, short asalert,
                             double cic, double Omega0, double cis, double I0,
                             double crc, double W, double OmegaDot, double IDot)
-         throw( InvalidRequest );
+         noexcept(false);
 
          /// Output the contents of this ephemeris to the given stream.
       void dump(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
       void setFIC(const bool arg);
 
       void dumpTerse(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
 
       bool haveSubframe[3];/**< flags indicating presence of a subframe */

--- a/core/lib/GNSSEph/EngNav.cpp
+++ b/core/lib/GNSSEph/EngNav.cpp
@@ -325,7 +325,7 @@ namespace gpstk
 
 
    EngNav::EngNav()
-      throw()
+      noexcept
    {
       short i=0, n=0;
       static short initialized = 0;
@@ -361,7 +361,7 @@ namespace gpstk
    bool EngNav :: subframeConvert(const long input[10],
                                   int gpsWeek,
                                   double output[60])
-      throw()
+      noexcept
    {
       uint32_t tinput[10];
       for (int n=0;n<10;++n)
@@ -373,7 +373,7 @@ namespace gpstk
    bool EngNav :: subframeConvert(const uint32_t input[10],
                                   short gpsWeek,
                                   double output[60])
-      throw()
+      noexcept
    {
       short patId = -2, i = 2;
       struct DecodeQuant *p=NULL;
@@ -425,7 +425,7 @@ namespace gpstk
 
       // Retained for backward compatibility
    bool EngNav :: convert8bit(int gpsWeek, double *output)
-      throw()
+      noexcept
    {
       short tgpsWeek = static_cast<short>( gpsWeek );
       short toutput = static_cast<short> ( *output );
@@ -437,7 +437,7 @@ namespace gpstk
 
       // Retained for backward compatibility
    bool EngNav :: convert10bit(int gpsWeek, double *output)
-      throw()
+      noexcept
    {
       short tgpsWeek = static_cast<short>( gpsWeek );
       short toutput = static_cast<short> ( *output );
@@ -467,7 +467,7 @@ namespace gpstk
 
       // Retained for backward compatibility
    short EngNav :: getSubframePattern(const long input[10])
-      throw()
+      noexcept
    {
       uint32_t tinput[10];
       for (int n=0;n<10;++n)
@@ -476,7 +476,7 @@ namespace gpstk
    }
 
    short EngNav :: getSubframePattern(const uint32_t input[10])
-      throw()
+      noexcept
    {
       short iret, svid;
       long  itemp;
@@ -513,7 +513,7 @@ namespace gpstk
 
 
    bool EngNav :: sv2page(short svpgid, short& subframe, short& page)
-      throw()
+      noexcept
    {
       if (svpgid < 1)
          return false;
@@ -572,7 +572,7 @@ namespace gpstk
 
 
    bool EngNav :: sfpage2svid(short subframe, short page, short& svpgid)
-      throw()
+      noexcept
    {
       static const short sf4pg[25] = { 57, 25, 26, 27, 28, 57, 29, 30, 31, 32,
                                        57, 62, 52, 53, 54, 57, 55, 56, 58, 59,
@@ -598,7 +598,7 @@ namespace gpstk
 
    bool EngNav :: zcount2page(unsigned long zcount,
                               short& subframe, short& page)
-      throw()
+      noexcept
    {
       subframe = ((zcount % 20) / 4);
       if (subframe == 0)
@@ -733,7 +733,7 @@ namespace gpstk
    void EngNav :: convertQuant(const uint32_t input[10],
                                double output[60],
                                DecodeQuant *p)
-      throw()
+      noexcept
    {
       double dval;
       short i, n, bit1, nword, nbit;
@@ -853,7 +853,7 @@ namespace gpstk
                                   CommonTime &tnmct,
                                   CommonTime &toe,
                                   CommonTime &tot)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       uint32_t toeSOW, offset;
       short sfid = getSFID(sf2[1]);

--- a/core/lib/GNSSEph/EngNav.hpp
+++ b/core/lib/GNSSEph/EngNav.hpp
@@ -75,7 +75,7 @@ namespace gpstk
       };
 
          /// default constructor
-      EngNav() throw();
+      EngNav() noexcept;
 
          /// destructor
       virtual ~EngNav() {}
@@ -181,7 +181,7 @@ namespace gpstk
       static bool subframeConvert(const long input[10],
                                   int gpsWeek,
                                   double output[60])
-         throw();
+         noexcept;
 
          /**
           * Given 10 words of a navigation message subframe (as
@@ -198,7 +198,7 @@ namespace gpstk
       static bool subframeConvert(const uint32_t input[10],
                                   short gpsWeek,
                                   double output[60])
-         throw();
+         noexcept;
 
          /** Convert the week number in \c out from 8-bit to full
           * using the full week number \c gpsWeek.
@@ -208,7 +208,7 @@ namespace gpstk
           * each other.
           */
       static bool convert8bit(int gpsWeek, double *out)
-         throw();
+         noexcept;
 
          /** Convert the week number in \c out from 10-bit to full
           * using the full week number \c gpsWeek.
@@ -218,7 +218,7 @@ namespace gpstk
           * each other.
           */
       static bool convert10bit(int gpsWeek, double *out)
-         throw();
+         noexcept;
 
          /** Convert the week number in \c out from 8 or 10-bit to full
           * using the full week number \c fullGPSWeek.
@@ -258,9 +258,9 @@ namespace gpstk
           * @return the pattern ID as defined in the above table.
           */
       static short getSubframePattern(const long input[10])
-         throw();
+         noexcept;
       static short getSubframePattern(const uint32_t input[10])
-         throw();
+         noexcept;
 
          /**
           * Given an SV/Page ID (1-63), set the subframe ID and page
@@ -275,7 +275,7 @@ namespace gpstk
           * be one of the possible pages for that SV/Page ID.
           */
       static bool sv2page(short svpgid, short& subframe, short& page)
-         throw();
+         noexcept;
 
 
          /**
@@ -289,7 +289,7 @@ namespace gpstk
           * be one of the possible pages for that SV/Page ID.
           */
       static bool sfpage2svid(short subframe, short page, short& svpgid)
-         throw();
+         noexcept;
 
 
          /**
@@ -303,7 +303,7 @@ namespace gpstk
           */
       static bool zcount2page(unsigned long zcount,
                               short& subframe, short& page)
-         throw();
+         noexcept;
 
          /**
           * Emit human-readable instance data to the specified stream.
@@ -332,12 +332,12 @@ namespace gpstk
                                   CommonTime &tnmct,
                                   CommonTime &toe,
                                   CommonTime &tot)
-         throw(InvalidParameter);
+         noexcept(false);
 
       static bool getNMCTValidity(const uint32_t sf2[10],
                                   unsigned   howWeek,
                                   NMCTMeta   &meta)
-         throw(InvalidParameter)
+         noexcept(false)
       {
          return getNMCTValidity(sf2, howWeek, meta.aodo, meta.tnmct, meta.toe,
                                 meta.tot);
@@ -366,7 +366,7 @@ namespace gpstk
       static void convertQuant(const uint32_t input[10],
                                double output[60],
                                DecodeQuant *p)
-         throw();
+         noexcept;
    }; // class EngNav
 
       //@}

--- a/core/lib/GNSSEph/GPS_URA.hpp
+++ b/core/lib/GNSSEph/GPS_URA.hpp
@@ -107,7 +107,7 @@ namespace gpstk
 
 
    inline
-   short accuracy2ura(const double& acc) throw()
+   short accuracy2ura(const double& acc) noexcept
    {
       short ura = 0;
       while ( (ura <= SV_ACCURACY_GPS_MAX_INDEX_VALUE) &&
@@ -119,7 +119,7 @@ namespace gpstk
    }
    
    inline
-   double ura2accuracy(const short& ura) throw()
+   double ura2accuracy(const short& ura) noexcept
    {
       if(ura < 0)
          return SV_ACCURACY_GPS_MAX_INDEX[0];
@@ -129,7 +129,7 @@ namespace gpstk
    }
 
    inline
-   short nominalAccuracy2ura(const double& acc) throw()
+   short nominalAccuracy2ura(const double& acc) noexcept
    {
       short ura = 0;
       while ( (ura <= SV_ACCURACY_GPS_MAX_INDEX_VALUE) &&
@@ -141,7 +141,7 @@ namespace gpstk
    }
    
    inline
-   double ura2nominalAccuracy(const short& ura) throw()
+   double ura2nominalAccuracy(const short& ura) noexcept
    {
       if(ura < 0)
          return SV_ACCURACY_GPS_NOMINAL_INDEX[0];
@@ -151,7 +151,7 @@ namespace gpstk
    }
 
    inline
-   short accuracy2CNAVura(const double& acc) throw()
+   short accuracy2CNAVura(const double& acc) noexcept
    {
       short ura = -15;
       while ( (ura <= SV_CNAV_ACCURACY_GPS_MAX_INDEX_VALUE) &&
@@ -164,7 +164,7 @@ namespace gpstk
 
    inline
    double ura2CNAVaccuracy(const short& ura) 
-      throw( InvalidRequest )
+      noexcept(false)
    {
       short ndx = ura+SV_CNAV_INDEX_OFFSET;
       if(ndx < 0 || ndx > SV_CNAV_NOMINAL_MAX_INDEX)
@@ -177,7 +177,7 @@ namespace gpstk
 
    inline
    double ura2CNAVNominalaccuracy(const short& ura)
-      throw( InvalidRequest )
+      noexcept(false)
    {
       short ndx = ura+SV_CNAV_INDEX_OFFSET;
       if(ndx < 0 || ndx > SV_CNAV_NOMINAL_MAX_INDEX)

--- a/core/lib/GNSSEph/GloEphemeris.cpp
+++ b/core/lib/GNSSEph/GloEphemeris.cpp
@@ -51,7 +51,7 @@ namespace gpstk
        *  @throw InvalidRequest if required data has not been stored.
        */
    Xvt GloEphemeris::svXvt(const CommonTime& epoch) const
-      throw( gpstk::InvalidRequest )
+      noexcept(false)
    {
 
          // Check that the given epoch is within the available time limits.
@@ -231,7 +231,7 @@ namespace gpstk
 
       // Get the epoch time for this ephemeris
    CommonTime GloEphemeris::getEphemerisEpoch() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
 
          // First, let's check if there is valid data
@@ -248,7 +248,7 @@ namespace gpstk
 
       // This function returns the PRN ID of the SV.
    short GloEphemeris::getPRNID() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
 
          // First, let's check if there is valid data
@@ -270,7 +270,7 @@ namespace gpstk
        * @throw InvalidRequest if required data has not been stored.
        */
    double GloEphemeris::svClockBias(const CommonTime& epoch) const
-      throw( gpstk::InvalidRequest )
+      noexcept(false)
    {
 
          // First, let's check if there is valid data
@@ -302,7 +302,7 @@ namespace gpstk
        * @throw InvalidRequest if required data has not been stored.
        */
    double GloEphemeris::svClockDrift(const CommonTime& epoch) const
-      throw( gpstk::InvalidRequest )
+      noexcept(false)
    {
 
          // First, let's check if there is valid data
@@ -321,7 +321,7 @@ namespace gpstk
 
       // Output the contents of this ephemeris to the given stream as a single line.
    void GloEphemeris::dump(std::ostream& s) const
-      throw()
+      noexcept
    {
 
       s << "Sys:" << satSys << ", PRN:" << PRNID

--- a/core/lib/GNSSEph/GloEphemeris.hpp
+++ b/core/lib/GNSSEph/GloEphemeris.hpp
@@ -86,7 +86,7 @@ namespace gpstk
           * @throw InvalidRequest if required data has not been stored.
           */
       Xvt svXvt(const CommonTime& epoch) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
          /** Compute satellite position & velocity at the given time
           *  using this ephemeris data.  HOWEVER, DO NOT check whether
@@ -102,24 +102,24 @@ namespace gpstk
 
          /// Get the epoch time for this ephemeris
       CommonTime getEphemerisEpoch() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
 
          /// Get the epoch time for this ephemeris
       CommonTime getEpochTime() const
-         throw( gpstk::InvalidRequest )
+         noexcept(false)
       { return getEphemerisEpoch(); };
 
 
          /** This functions returns the GNSS type (satellite system code) */
       std::string getSatSys() const
-         throw()
+         noexcept
       { return satSys; };
 
 
          /// This function returns the PRN ID of the SV.
       short getPRNID() const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
 
          /** Compute the satellite clock bias (sec) at the given time
@@ -129,7 +129,7 @@ namespace gpstk
           * @throw InvalidRequest if required data has not been stored.
           */
       double svClockBias(const CommonTime& epoch) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
 
          /** Compute the satellite clock drift (sec/sec) at the given time
@@ -139,7 +139,7 @@ namespace gpstk
           * @throw InvalidRequest if required data has not been stored.
           */
       double svClockDrift(const CommonTime& t) const
-         throw( gpstk::InvalidRequest );
+         noexcept(false);
 
 
          /// Get integration step for Runge-Kutta algorithm.
@@ -157,49 +157,49 @@ namespace gpstk
 
          /// Get the acceleration vector.
       Triple getAcc() const
-         throw()
+         noexcept
       { return a; }
 
 
          /// Get the TauN parameter.
       double getTauN() const
-         throw()
+         noexcept
       { return clkbias; }
 
 
          /// Get the GammaN parameter.
       double getGammaN() const
-         throw()
+         noexcept
       { return clkdrift; }
 
 
          /// Get the MFTime parameter.
       long getMFtime() const
-         throw()
+         noexcept
       { return MFtime; }
 
 
          /// Get the health value parameter.
       short getHealth() const
-         throw()
+         noexcept
       { return health; }
 
 
          /// Get the frequency number.
       short getfreqNum() const
-         throw()
+         noexcept
       { return freqNum; }
 
 
          /// Get the age of the information.
       double getAgeOfInfo() const
-         throw()
+         noexcept
       { return ageOfInfo; }
 
 
          /// Output the contents of this ephemeris to the given stream.
       void dump(std::ostream& s = std::cout) const
-         throw();
+         noexcept;
          
       void prettyDump(std::ostream& s) const;
       void terseDump(std::ostream& s) const;

--- a/core/lib/GNSSEph/GloEphemerisStore.cpp
+++ b/core/lib/GNSSEph/GloEphemerisStore.cpp
@@ -167,7 +167,7 @@ namespace gpstk
 
 
    Xvt GloEphemerisStore::computeXvt(const SatID& sat,
-                                     const CommonTime& epoch) const throw()
+                                     const CommonTime& epoch) const noexcept
    {
       Xvt rv;
       rv.health = Xvt::HealthStatus::Unavailable;
@@ -247,7 +247,7 @@ namespace gpstk
 
    Xvt::HealthStatus GloEphemerisStore::getSVHealth(const SatID& sat,
                                                     const CommonTime& epoch)
-      const throw()
+      const noexcept
    {
       Xvt::HealthStatus rv = Xvt::HealthStatus::Unavailable;
       try

--- a/core/lib/GNSSEph/GloEphemerisStore.hpp
+++ b/core/lib/GNSSEph/GloEphemerisStore.hpp
@@ -130,7 +130,7 @@ namespace gpstk
           * @param[in] t the time to look up
           * @return the Xvt of the object at the indicated time */
       virtual Xvt computeXvt(const SatID& id, const CommonTime& t)
-         const throw();
+         const noexcept;
 
          /** Get the satellite health at a specific time.
           * @param[in] id the object's identifier
@@ -138,7 +138,7 @@ namespace gpstk
           * @return the health status of the object at the indicated time. */
       virtual Xvt::HealthStatus getSVHealth(const SatID& id,
                                             const CommonTime& t)
-         const throw();
+         const noexcept;
 
          /// Get integration step for Runge-Kutta algorithm.
       double getIntegrationStep() const

--- a/core/lib/GNSSEph/OrbElem.cpp
+++ b/core/lib/GNSSEph/OrbElem.cpp
@@ -63,7 +63,7 @@ namespace gpstk
    } 
 
    bool OrbElem::isValid(const CommonTime& ct) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -130,7 +130,7 @@ namespace gpstk
    }
 
    double OrbElem::svClockBias(const CommonTime& t) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -144,7 +144,7 @@ namespace gpstk
    }
 
    double OrbElem::svClockBiasM(const CommonTime& t) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -157,7 +157,7 @@ namespace gpstk
    }
 
    double OrbElem::svClockDrift(const CommonTime& t) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -181,7 +181,7 @@ namespace gpstk
       // Adot and dndot variables are appropriately set to 0.0 by the 
       // LNAV loaders. 
    Xvt OrbElem::svXvt(const CommonTime& t) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -343,7 +343,7 @@ namespace gpstk
    }
 
    double OrbElem::svRelativity(const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -451,7 +451,7 @@ namespace gpstk
    }
 
    void OrbElem::dumpBody(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -529,7 +529,7 @@ namespace gpstk
    } // end of dumpBody()
 
    void OrbElem::dumpHeader(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       s << "****************************************************************"
         << "************" << endl
@@ -563,11 +563,11 @@ namespace gpstk
    }
 
    void OrbElem::dumpFooter(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {}
 
    void OrbElem::dump(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       dumpHeader(s);
       dumpBody(s);

--- a/core/lib/GNSSEph/OrbElem.hpp
+++ b/core/lib/GNSSEph/OrbElem.hpp
@@ -91,7 +91,7 @@ namespace gpstk
           * Returns true if the time, ct, is within the period of validity of this OrbElem object.
           * @throw Invalid Request if the required data has not been stored.
           */
-      virtual bool isValid(const CommonTime& ct) const throw(InvalidRequest);
+      virtual bool isValid(const CommonTime& ct) const noexcept(false);
 
       virtual std::string getName() const = 0;
 
@@ -104,17 +104,17 @@ namespace gpstk
          /** Compute the satellite clock bias (sec) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      double svClockBias(const CommonTime& t) const throw(gpstk::InvalidRequest);
+      double svClockBias(const CommonTime& t) const noexcept(false);
 
          /** Compute the satellite clock bias (meters) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      double svClockBiasM(const CommonTime& t) const throw(gpstk::InvalidRequest);
+      double svClockBiasM(const CommonTime& t) const noexcept(false);
 
          /** Compute the satellite clock drift (sec/sec) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      double svClockDrift(const CommonTime& t) const throw(gpstk::InvalidRequest);
+      double svClockDrift(const CommonTime& t) const noexcept(false);
 
 
          /** Compute satellite position at the given time
@@ -123,12 +123,12 @@ namespace gpstk
           * This is virtual due to need to eventually address other 
           * methods of orbit determination.
           */
-      virtual Xvt svXvt(const CommonTime& t) const throw(gpstk::InvalidRequest);
+      virtual Xvt svXvt(const CommonTime& t) const noexcept(false);
 
          /** Compute satellite relativity correction (sec) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      double svRelativity(const CommonTime& t) const throw( gpstk::InvalidRequest );
+      double svRelativity(const CommonTime& t) const noexcept(false);
 
 
          /** adjustBeginningValidity is provided to support
@@ -153,19 +153,19 @@ namespace gpstk
       static void timeDisplay(std::ostream & os, const CommonTime& t);
 
       virtual void dumpTerse(std::ostream& s = std::cout) const
-         throw( InvalidRequest ) = 0;
+         noexcept(false) = 0;
 
       virtual void dumpHeader(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
       virtual void dumpBody(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
       virtual void dumpFooter(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
       virtual void dump(std::ostream& s = std::cout) const
-	 throw( InvalidRequest );
+	 noexcept(false);
 
 	 /// Harmonic perturbations
          //@{

--- a/core/lib/GNSSEph/OrbElemBase.cpp
+++ b/core/lib/GNSSEph/OrbElemBase.cpp
@@ -63,7 +63,7 @@ namespace gpstk
    }
 
    bool OrbElemBase::isValid(const CommonTime& ct) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -81,7 +81,7 @@ namespace gpstk
    }
 
    bool OrbElemBase::isHealthy() const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -135,7 +135,7 @@ namespace gpstk
       // body, and footer are called, and any output formats are
       // preserved. 
    void OrbElemBase::dump(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -153,7 +153,7 @@ namespace gpstk
 
 
    Rinex3NavData OrbElemBase::makeRinex3NavData() const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       InvalidRequest ir("Method makeRinex3NavData() not implemented.");
       GPSTK_THROW(ir); 

--- a/core/lib/GNSSEph/OrbElemBase.hpp
+++ b/core/lib/GNSSEph/OrbElemBase.hpp
@@ -92,7 +92,7 @@ namespace gpstk
 	  * OrbElemBase object.
           * @throw Invalid Request if the required data has not been stored.
           */
-      virtual bool isValid(const CommonTime& ct) const throw(InvalidRequest);
+      virtual bool isValid(const CommonTime& ct) const noexcept(false);
 
 	 /**
           *   Return true if orbit data have been loaded.
@@ -108,38 +108,38 @@ namespace gpstk
          /** This function returns the health status of the SV.
           * @throw Invalid Request if the required data has not been stored.
           */
-      bool isHealthy() const throw(gpstk::InvalidRequest);
+      bool isHealthy() const noexcept(false);
 
          /// Set the SV health status.  Child classes may do more.
-      virtual void setHealthy(bool h) throw()
+      virtual void setHealthy(bool h) noexcept
       { healthy = h; }
 
          /** Compute the satellite clock bias (sec) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      virtual double svClockBias(const CommonTime& t) const throw(gpstk::InvalidRequest) = 0;
+      virtual double svClockBias(const CommonTime& t) const noexcept(false) = 0;
 
          /** Compute the satellite clock bias (meters) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      virtual double svClockBiasM(const CommonTime& t) const throw(gpstk::InvalidRequest) = 0;
+      virtual double svClockBiasM(const CommonTime& t) const noexcept(false) = 0;
 
          /** Compute the satellite clock drift (sec/sec) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      virtual double svClockDrift(const CommonTime& t) const throw(gpstk::InvalidRequest) = 0;
+      virtual double svClockDrift(const CommonTime& t) const noexcept(false) = 0;
 
 
          /** Compute satellite position at the given time
           * using this orbit data.
           * @throw Invalid Request if the required data has not been stored.
           */
-      virtual Xvt svXvt(const CommonTime& t) const throw(gpstk::InvalidRequest) = 0;
+      virtual Xvt svXvt(const CommonTime& t) const noexcept(false) = 0;
 
          /** Compute satellite relativity correction (sec) at the given time
           *  @throw Invalid Request if the required data has not been stored.
           */
-      virtual double svRelativity(const CommonTime& t) const throw( gpstk::InvalidRequest ) = 0;
+      virtual double svRelativity(const CommonTime& t) const noexcept(false) = 0;
 
           /** Returns true if this two objects are 
            *   a.) same concrete type, and
@@ -168,22 +168,22 @@ namespace gpstk
           * @throw Invalid Request if the required data has not been stored.
           */
       virtual void dumpTerse(std::ostream& s = std::cout) const
-         throw( InvalidRequest ) = 0;
+         noexcept(false) = 0;
 
       virtual void dumpHeader(std::ostream& s = std::cout) const
-         throw( InvalidRequest ) = 0;
+         noexcept(false) = 0;
 
       virtual void dumpBody(std::ostream& s = std::cout) const
-         throw( InvalidRequest ) = 0;
+         noexcept(false) = 0;
 
       virtual void dumpFooter(std::ostream& s = std::cout) const
-         throw( InvalidRequest ) = 0;
+         noexcept(false) = 0;
 
       virtual void dump(std::ostream& s = std::cout) const
-	       throw( InvalidRequest );
+	       noexcept(false);
 
       virtual Rinex3NavData makeRinex3NavData() const
-         throw( InvalidRequest );
+         noexcept(false);
 
          /// Overhead information
          //@{

--- a/core/lib/GNSSEph/OrbElemRinex.cpp
+++ b/core/lib/GNSSEph/OrbElemRinex.cpp
@@ -69,14 +69,14 @@ namespace gpstk
 
    //----------------------------------------------------------------
    OrbElemRinex::OrbElemRinex( const RinexNavData& rinNav )
-      throw( InvalidParameter )
+      noexcept(false)
    {
       loadData( rinNav );
    }
 
    //----------------------------------------------------------------
    OrbElemRinex::OrbElemRinex( const Rinex3NavData& rinNav )
-     throw( InvalidParameter )
+     noexcept(false)
    {
       loadData( rinNav );
    }
@@ -90,7 +90,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void OrbElemRinex::loadData( const RinexNavData& rinNav )
-      throw( InvalidParameter )
+      noexcept(false)
    {
       // Fill in the variables unique to OrbElemFIC9
       codeflags        = rinNav.codeflgs;
@@ -241,7 +241,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void OrbElemRinex::loadData( const Rinex3NavData& rinNav )
-     throw( InvalidParameter )
+     noexcept(false)
    {
       // Fill in the variables unique to OrbElemFIC9
       codeflags        = rinNav.codeflgs;
@@ -325,7 +325,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    double OrbElemRinex::getAccuracy()  const
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -626,7 +626,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void OrbElemRinex::dumpHeader(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!dataLoaded())
       {
@@ -707,7 +707,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void OrbElemRinex :: dumpTerse(ostream& s) const
-      throw(InvalidRequest )
+      noexcept(false)
    {
 
        // Check if the subframes have been loaded before attempting
@@ -767,7 +767,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void OrbElemRinex :: dump(ostream& s) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       ios::fmtflags oldFlags = s.flags();
       dumpHeader(s);

--- a/core/lib/GNSSEph/OrbElemRinex.hpp
+++ b/core/lib/GNSSEph/OrbElemRinex.hpp
@@ -64,10 +64,10 @@ namespace gpstk
       OrbElemRinex();
 
       OrbElemRinex( const Rinex3NavData& rinNav )
-         throw( InvalidParameter );
+         noexcept(false);
 
       OrbElemRinex( const RinexNavData& rinNav )
-	 throw( InvalidParameter); 
+	 noexcept(false); 
 
          /// Destructor
       virtual ~OrbElemRinex() {}
@@ -79,13 +79,13 @@ namespace gpstk
            *  @throw InvalidParameter if the data are not consistent.
            */ 
       void loadData( const RinexNavData& rinNav )
-	       throw( InvalidParameter); 
+	       noexcept(false); 
 
          /** Load an existing object from a Rinex3NavData object. 
            * @throw InvalidParameter if the data are not consistent.
            */
       void loadData( const Rinex3NavData& rinNav )
-         throw( InvalidParameter );
+         noexcept(false);
 
       virtual std::string getName() const
       {
@@ -99,36 +99,36 @@ namespace gpstk
       
          /// Returns the upper bound of the URA range
       double getAccuracy()  const
-         throw( InvalidRequest );
+         noexcept(false);
  
         /* Should only be used by GPSOrbElemStore::rationalize()
          */
       void adjustBeginningValidity();
 
       virtual void dumpHeader(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
          /** Generate a formatted human-readable output of the entire contents of
           *  this object and send it to the designated output stream (default to cout).
           *  @throw Invalid Parameter if the object has been instantiated, but not loaded.
           */
       void dump(std::ostream& s = std::cout) const
-         throw( InvalidRequest );  
+         noexcept(false);  
          /** Generate a formatted human-readable one-line output that summarizes
           *  the critical times associated with this object and send it to the
           *  designated output stream (default to cout).
           *  @throw Invalid Parameter if the object has been instantiated, but not loaded.
           */   
       void dumpTerse(std::ostream& s = std::cout) const
-         throw( InvalidRequest );
+         noexcept(false);
 
          /// Accessor for the \c health data member.
-      short getHealth() const throw()
+      short getHealth() const noexcept
       { return health; }
 
          /** Set the \c health data member to the value of h and
           * update the \c healthy flag. */
-      virtual void setHealth(short h) throw()
+      virtual void setHealth(short h) noexcept
       {
          health = h;
          OrbElem::setHealthy(health == 0);
@@ -137,7 +137,7 @@ namespace gpstk
          /** Set the \c health data member to either 0 or non-zero,
           * depending on the requested value of h (true=0,
           * false=non-zero). */
-      virtual void setHealthy(bool h) throw()
+      virtual void setHealthy(bool h) noexcept
       {
          OrbElem::setHealthy(h);
          health = (h ? 0 : 1);

--- a/core/lib/GNSSEph/OrbElemStore.cpp
+++ b/core/lib/GNSSEph/OrbElemStore.cpp
@@ -63,7 +63,7 @@ namespace gpstk
 //--------------------------------------------------------------------------
 
    Xvt OrbElemStore::getXvt(const SatID& sat, const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       try
       {
@@ -89,7 +89,7 @@ namespace gpstk
 
 
    Xvt OrbElemStore::computeXvt(const SatID& sat, const CommonTime& t) const
-      throw()
+      noexcept
    {
       Xvt rv;
       rv.health = Xvt::HealthStatus::Unavailable;
@@ -113,7 +113,7 @@ namespace gpstk
 
 
    Xvt::HealthStatus OrbElemStore ::
-   getSVHealth(const SatID& sat, const CommonTime& t) const throw()
+   getSVHealth(const SatID& sat, const CommonTime& t) const noexcept
    {
       Xvt::HealthStatus rv = Xvt::HealthStatus::Unavailable;
       try
@@ -135,7 +135,7 @@ namespace gpstk
 //------------------------------------------------------------------------------
 
    void OrbElemStore::validSatSystem(const SatID& sat) const 
-      throw( InvalidRequest )
+      noexcept(false)
    {
       if (!isSatSysPresent(sat.system))
       {
@@ -162,7 +162,7 @@ namespace gpstk
 // listing behavior.
 
    void OrbElemStore::dump(std::ostream& s, short detail) const
-      throw()
+      noexcept
    {
       UBEMap::const_iterator it;
       static const string fmt("%04Y/%02m/%02d %02H:%02M:%02S %P");
@@ -210,7 +210,7 @@ namespace gpstk
 // It should keep the one with the earliest transmit time.
 //------------------------------------------------------------------------------------ 
    bool OrbElemStore::addOrbElem(const OrbElemBase* eph)
-      throw(InvalidParameter,Exception)
+      noexcept(false)
    {
      bool dbg = false;
      //if (eph->satID.id==2 ||
@@ -369,7 +369,7 @@ namespace gpstk
 //-----------------------------------------------------------------------------
 
    void OrbElemStore::edit(const CommonTime& tmin, const CommonTime& tmax)
-      throw()
+      noexcept
    {
       for(UBEMap::iterator i = ube.begin(); i != ube.end(); i++)
       {
@@ -399,7 +399,7 @@ namespace gpstk
 //-----------------------------------------------------------------------------
 
    unsigned OrbElemStore::size() const
-      throw()
+      noexcept
    {
       unsigned counter = 0;
       for(UBEMap::const_iterator i = ube.begin(); i != ube.end(); i++)
@@ -410,7 +410,7 @@ namespace gpstk
 
 //-----------------------------------------------------------------------------
    bool OrbElemStore::isPresent(const SatID& id) const 
-      throw()
+      noexcept
    {
       UBEMap::const_iterator ci = ube.find(id);
       if (ci==ube.end()) return false;
@@ -429,7 +429,7 @@ namespace gpstk
 
    const OrbElemBase*
    OrbElemStore::findOrbElem(const SatID& sat, const CommonTime& t) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
           // Check to see that there exists a map of orbital elements
 	  // relevant to this SV.
@@ -521,7 +521,7 @@ namespace gpstk
  
    const OrbElemBase*
    OrbElemStore::findNearOrbElem(const SatID& sat, const CommonTime& t) const
-      throw(InvalidRequest)
+      noexcept(false)
    {
         // Check for any OrbElem for this SV            
       UBEMap::const_iterator prn_i = ube.find(sat);
@@ -594,7 +594,7 @@ namespace gpstk
 //-----------------------------------------------------------------------------
    const OrbElemBase* OrbElemStore::
    findToe(const SatID& sat, const CommonTime& t)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
          // If the TimeSystem of the requested t doesn't match
          // the TimeSystem stored in this store, throw an error.
@@ -646,7 +646,7 @@ namespace gpstk
 //-----------------------------------------------------------------------------
 
    int OrbElemStore::addToList(std::list<OrbElemBase*>& v) const
-      throw()
+      noexcept
    {
       int n = 0;
       UBEMap::const_iterator prn_i;
@@ -667,7 +667,7 @@ namespace gpstk
 
    /// Remove all data from this collection.
    void OrbElemStore::clear()
-         throw()
+         noexcept
    {
       for( UBEMap::iterator ui = ube.begin(); ui != ube.end(); ui++)
       {
@@ -688,7 +688,7 @@ namespace gpstk
 
    const OrbElemStore::OrbElemMap&
    OrbElemStore::getOrbElemMap( const SatID& sat ) const
-      throw( InvalidRequest )
+      noexcept(false)
    {
       validSatSystem(sat);
 

--- a/core/lib/GNSSEph/OrbElemStore.hpp
+++ b/core/lib/GNSSEph/OrbElemStore.hpp
@@ -71,7 +71,7 @@ namespace gpstk
    public:
       
       OrbElemStore()
-         throw()
+         noexcept
         :initialTime(CommonTime::END_OF_TIME), 
          finalTime(CommonTime::BEGINNING_OF_TIME),
          timeSysForStore(TimeSystem::Any)
@@ -118,7 +118,7 @@ namespace gpstk
       ///    reason, this is thrown. The text may have additional
       ///    information as to why the request failed.
       virtual Xvt getXvt(const SatID& id, const CommonTime& t)
-         const throw( InvalidRequest );
+         const noexcept(false);
 
          /** Compute the position, velocity and clock offset of the
           * indicated object in ECEF coordinates (meters) at the
@@ -135,41 +135,41 @@ namespace gpstk
           * @param[in] t the time to look up
           * @return the Xvt of the object at the indicated time */
       virtual Xvt computeXvt(const SatID& id, const CommonTime& t) const
-         throw();
+         noexcept;
 
          /** Get the satellite health at a specific time.
           * @param[in] id the object's identifier
           * @param[in] t the time to look up
           * @return the health status of the object at the indicated time. */
       virtual Xvt::HealthStatus getSVHealth(const SatID& id,
-                                            const CommonTime& t) const throw();
+                                            const CommonTime& t) const noexcept;
 
       /// A debugging function that outputs in human readable form,
       /// all data stored in this object.
       /// @param[in] s the stream to receive the output; defaults to cout
       /// @param[in] detail the level of detail to provide
       virtual void dump(std::ostream& s = std::cout, short detail = 0)
-         const throw();
+         const noexcept;
 
       virtual bool addOrbElem(const OrbElemBase* eph)
-         throw(InvalidParameter,Exception);
+         noexcept(false);
 
       /// Edit the dataset, removing data outside the indicated time interval
       /// @param[in] tmin defines the beginning of the time interval
       /// @param[in] tmax defines the end of the time interval
       virtual void edit(const CommonTime& tmin, 
                         const CommonTime& tmax = CommonTime::END_OF_TIME)
-         throw(); 
+         noexcept; 
 
       /// Clear the dataset, meaning remove all data
-      virtual void clear(void) throw();
+      virtual void clear(void) noexcept;
 
       /// Determine the earliest time for which this object can successfully 
       /// determine the Xvt for any object.
       /// @return The initial time
       /// @throw InvalidRequest This is thrown if the object has no data.
       virtual CommonTime getInitialTime() const
-         throw()
+         noexcept
          { return initialTime; }
 
 
@@ -178,23 +178,23 @@ namespace gpstk
       /// @return The final time
       /// @throw InvalidRequest This is thrown if the object has no data.
       virtual CommonTime getFinalTime() const
-         throw()
+         noexcept
          { return finalTime; }
 
       /// Return the number of orbit/clock elements stored in this store. 
       virtual unsigned size() const
-         throw(); 
+         noexcept; 
 
       virtual bool velocityIsPresent()
-         const throw()
+         const noexcept
          { return true; }
 
       /// Return true if velocity data is present in the store
-      virtual bool hasVelocity() const throw()
+      virtual bool hasVelocity() const noexcept
          { return true; }
 
       /// Return true if the given SatID is present in the store
-      virtual bool isPresent(const SatID& id) const throw();
+      virtual bool isPresent(const SatID& id) const noexcept;
 
       /// Classes to set/access the store TimeSystem information.
       TimeSystem getTimeSystem() const { return timeSysForStore; }
@@ -204,7 +204,7 @@ namespace gpstk
       bool isSatSysPresent(const SatID::SatelliteSystem ss) const;
       void addSatSys(const SatID::SatelliteSystem ss); 
       void validSatSystem(const SatID& sat) const 
-         throw( InvalidRequest );
+         noexcept(false);
       /*
        *  Explanation of find( ) function for OrbElemStore
        *  
@@ -221,7 +221,7 @@ namespace gpstk
       /// @return a reference to the desired OrbElemBase
       /// @throw InvalidRequest object thrown when no OrbElemBase is found
       const OrbElemBase* findOrbElem( const SatID& sat, const CommonTime& t )
-         const throw( InvalidRequest );
+         const noexcept(false);
 
       /// Find an OrbElemBase for the indicated satellite at time t. The OrbElemBase
       /// chosen is the one with HOW time closest to the time t, (i.e. with
@@ -231,7 +231,7 @@ namespace gpstk
       /// @return a reference to desired OrbElemBase
       /// @throw InvalidRequest object thrown when no OrbElemBase is found
       const OrbElemBase* findNearOrbElem( const SatID& sat, const CommonTime& t )
-         const throw( InvalidRequest );
+         const noexcept(false);
 
       /// Find an OrbElemBase for the indicated satellite that has a Toe
       /// corresponding to time t.  If no such OrbElemBase exists in the store,
@@ -241,7 +241,7 @@ namespace gpstk
       /// @return a reference to desired OrbElemBase
       /// @throw InvalidRequest object thrown when no OrbElemBase is found
       const OrbElemBase* findToe(const SatID& sat, const CommonTime& t)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
       /// Return a list of SatID object representing the satellites that
       /// are contained in the store.
@@ -253,7 +253,7 @@ namespace gpstk
       /// Add all ephemerides to an existing list<OrbElemBase>.
       /// @return the number of ephemerides added.
       int addToList( std::list<OrbElemBase*>& v ) const
-         throw();
+         noexcept;
 
       /// This is intended to store sets of unique orbital elements for a single SV.
       /// The key is the beginning of the period of validity for each set of elements. 
@@ -264,7 +264,7 @@ namespace gpstk
       /// const reference.  The intent is to provide "read only" access
       /// for analysis.  If the map needs to be modified, see other methods.
       const OrbElemMap& getOrbElemMap( const SatID& sat ) const
-         throw( InvalidRequest );
+         noexcept(false);
 
       protected:
      

--- a/core/lib/GNSSEph/OrbitEphStore.cpp
+++ b/core/lib/GNSSEph/OrbitEphStore.cpp
@@ -91,7 +91,7 @@ namespace gpstk
 
 
    Xvt OrbitEphStore::computeXvt(const SatID& sat, const CommonTime& t) const
-      throw()
+      noexcept
    {
       Xvt rv;
       rv.health = Xvt::HealthStatus::Unavailable;
@@ -115,7 +115,7 @@ namespace gpstk
 
 
    Xvt::HealthStatus OrbitEphStore ::
-   getSVHealth(const SatID& sat, const CommonTime& t) const throw()
+   getSVHealth(const SatID& sat, const CommonTime& t) const noexcept
    {
       Xvt::HealthStatus rv = Xvt::HealthStatus::Unavailable;
       try

--- a/core/lib/GNSSEph/OrbitEphStore.hpp
+++ b/core/lib/GNSSEph/OrbitEphStore.hpp
@@ -118,14 +118,14 @@ namespace gpstk
           * @param[in] t the time to look up
           * @return the Xvt of the object at the indicated time */
       virtual Xvt computeXvt(const SatID& id, const CommonTime& t) const
-         throw();
+         noexcept;
 
          /** Get the satellite health at a specific time.
           * @param[in] id the object's identifier
           * @param[in] t the time to look up
           * @return the health status of the object at the indicated time. */
       virtual Xvt::HealthStatus getSVHealth(const SatID& id,
-                                            const CommonTime& t) const throw();
+                                            const CommonTime& t) const noexcept;
 
          /** Output summary of store data in human readable form, with detail:
           *  0: Time limits and number of entries for entire store

--- a/core/lib/GNSSEph/PackedNavBits.cpp
+++ b/core/lib/GNSSEph/PackedNavBits.cpp
@@ -222,7 +222,7 @@ namespace gpstk
          /***    UNPACKING FUNCTIONS *********************************/
    uint64_t PackedNavBits::asUint64_t(const int startBit, 
                                       const int numBits ) const
-      throw(InvalidParameter)                                    
+      noexcept(false)                                    
    {
       uint64_t temp = 0L;       // Set up a temporary variable with a known size
                                 // It needs to be AT LEAST 33 bits.
@@ -464,7 +464,7 @@ namespace gpstk
    void PackedNavBits::addUnsignedLong( const unsigned long value, 
                                         const int numBits,
                                         const int scale ) 
-      throw(InvalidParameter)
+      noexcept(false)
    {
       uint64_t out = (uint64_t) value;
       out /= scale;
@@ -479,7 +479,7 @@ namespace gpstk
    }  
 
    void PackedNavBits::addLong( const long value, const int numBits, const int scale ) 
-      throw(InvalidParameter)
+      noexcept(false)
    {
       union
       {
@@ -500,7 +500,7 @@ namespace gpstk
 
    void PackedNavBits::addUnsignedDouble( const double value, const int numBits,
                                           const int power2 ) 
-      throw(InvalidParameter)
+      noexcept(false)
    {
       uint64_t out = (uint64_t) ScaleValue(value, power2);
       uint64_t test = pow(static_cast<double>(2),numBits) - 1;
@@ -515,7 +515,7 @@ namespace gpstk
 
    void PackedNavBits::addSignedDouble( const double value, const int numBits,
                                         const int power2 ) 
-      throw(InvalidParameter)
+      noexcept(false)
    {
       union
       {
@@ -534,7 +534,7 @@ namespace gpstk
 
    void PackedNavBits::addDoubleSemiCircles( const double Radians, const int numBits, 
                                              const int power2)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       union
       {
@@ -553,7 +553,7 @@ namespace gpstk
    }
 
    void PackedNavBits::addString( const string String, const int numChars ) 
-      throw(InvalidParameter)
+      noexcept(false)
    {
       int numPadBlanks = 0;
       int numToCopy = 0;
@@ -594,7 +594,7 @@ namespace gpstk
    }  
 
    void PackedNavBits::addPackedNavBits(const PackedNavBits& right)
-      throw(InvalidParameter)
+      noexcept(false)
    {
       int old_bits_used = bits_used;
       bits_used += right.bits_used;
@@ -690,7 +690,7 @@ namespace gpstk
    void PackedNavBits::copyBits(const PackedNavBits& from, 
                                 const short startBit, 
                                 const short endBit)
-                                throw(InvalidParameter)
+                                noexcept(false)
    {
       if (bits_used != from.bits_used)
       {
@@ -717,7 +717,7 @@ namespace gpstk
                            const int startBit,
                            const int numBits,
                            const int scale)
-                           throw(InvalidParameter)
+                           noexcept(false)
    {
       if ((startBit+numBits)>bits_used)
       {
@@ -792,7 +792,7 @@ namespace gpstk
    }
  
    void PackedNavBits::dump(ostream& s) const
-      throw()
+      noexcept
    {
       ios::fmtflags oldFlags = s.flags();
    
@@ -968,7 +968,7 @@ namespace gpstk
    }
       
    void PackedNavBits::rawBitInput(const std::string inString )
-      throw(InvalidParameter)
+      noexcept(false)
    {
          // Debug
          //  Find first non-white space string.   

--- a/core/lib/GNSSEph/PackedNavBits.hpp
+++ b/core/lib/GNSSEph/PackedNavBits.hpp
@@ -125,7 +125,7 @@ namespace gpstk
       size_t getNumBits() const;
 
          /* Output the contents of this class to the given stream. */
-      void dump(std::ostream& s = std::cout) const throw();
+      void dump(std::ostream& s = std::cout) const noexcept;
       
          /***    UNPACKING FUNCTIONS *********************************/
          /* Unpack an unsigned long integer */
@@ -220,31 +220,31 @@ namespace gpstk
       void addUnsignedLong( const unsigned long value, 
                             const int numBits,  
                             const int scale ) 
-         throw(InvalidParameter);
+         noexcept(false);
         
          /* Pack a signed long integer */                     
       void addLong( const long value, 
                     const int numBits, 
                     const int scale )
-         throw(InvalidParameter);
+         noexcept(false);
 
          /* Pack an unsigned double */
       void addUnsignedDouble( const double value, 
                               const int numBits, 
                               const int power2)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /* Pack a signed double */
       void addSignedDouble( const double value, 
                             const int numBits, 
                             const int power2)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /* Pack a double with units of semicircles */
       void addDoubleSemiCircles( const double radians, 
                                  const int numBits, 
                                  const int power2)
-         throw(InvalidParameter);
+         noexcept(false);
 
          /**
           * Pack a string.
@@ -254,10 +254,10 @@ namespace gpstk
           * If numChars > length of String, blanks will be added at the end. */
       void addString(const std::string String, 
                      const int numChars)
-         throw(InvalidParameter);
+         noexcept(false);
       
       void addPackedNavBits( const PackedNavBits &pnb)
-         throw(InvalidParameter);
+         noexcept(false);
    
          /*
           * Output the packed bits as a set of 32 bit
@@ -380,7 +380,7 @@ namespace gpstk
       void copyBits(const PackedNavBits& from, 
                     const short startBit=0, 
                     const short endBit=-1)
-                    throw(InvalidParameter);
+                    noexcept(false);
 
          /**
           * This method is not typically used in production; however it
@@ -395,7 +395,7 @@ namespace gpstk
                               const int startBit,
                               const int numBits,
                               const int scale=1 )
-                              throw(InvalidParameter);
+                              noexcept(false);
          /**
           *  Reset number of bits
           */
@@ -418,7 +418,7 @@ namespace gpstk
           * The function returns if the read is succeessful.
           * Otherwise,the function throws an exception */
        void rawBitInput(const std::string inString )
-          throw(InvalidParameter);       
+          noexcept(false);       
 
        void setXmitCoerced(bool tf=true) {xMitCoerced=tf;}
        bool isXmitCoerced() const {return xMitCoerced;}
@@ -446,7 +446,7 @@ namespace gpstk
 
          /** Unpack the bits */
       uint64_t asUint64_t(const int startBit, const int numBits ) const 
-         throw(InvalidParameter);
+         noexcept(false);
 
          /** Pack the bits */
       void addUint64_t( const uint64_t value, const int numBits );

--- a/core/lib/GNSSEph/PositionSatStore.cpp
+++ b/core/lib/GNSSEph/PositionSatStore.cpp
@@ -51,7 +51,7 @@ namespace gpstk
    //@{
 
    // Output stream operator is used by dump() in TabularSatStore
-   ostream& operator<<(ostream& os, const PositionRecord& rec) throw()
+   ostream& operator<<(ostream& os, const PositionRecord& rec) noexcept
    {
       os << "Pos" << fixed << setprecision(6)
          << " " << setw(13) << rec.Pos[0]
@@ -91,7 +91,7 @@ namespace gpstk
    //  b) checkDataGap is true and there is a data gap
    //  c) checkInterval is true and the interval is larger than maxInterval
    PositionRecord PositionSatStore::getValue(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          bool isExact;
@@ -194,7 +194,7 @@ namespace gpstk
    //  b) checkDataGap is true and there is a data gap
    //  c) checkInterval is true and the interval is larger than maxInterval
    Triple PositionSatStore::getPosition(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          int i;
@@ -239,7 +239,7 @@ namespace gpstk
    //  b) checkDataGap is true and there is a data gap
    //  c) checkInterval is true and the interval is larger than maxInterval
    Triple PositionSatStore::getVelocity(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          int i;
@@ -293,7 +293,7 @@ namespace gpstk
    //  c) checkInterval is true and the interval is larger than maxInterval
    //  d) neither velocity nor acceleration data are present
    Triple PositionSatStore::getAcceleration(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       if(!haveVelocity && !haveAcceleration) {
          InvalidRequest e("Neither velocity nor acceleration data are present");
@@ -345,7 +345,7 @@ namespace gpstk
    // Add a PositionRecord to the store.
    void PositionSatStore::addPositionRecord(const SatID& sat, const CommonTime& ttag,
                                             const PositionRecord& rec)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -377,7 +377,7 @@ namespace gpstk
    // Add position data (only) to the store
    void PositionSatStore::addPositionData(const SatID& sat, const CommonTime& ttag,
                      const Triple& Pos, const Triple& Sig)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -404,7 +404,7 @@ namespace gpstk
    // Add velocity data (only) to the store
    void PositionSatStore::addVelocityData(const SatID& sat, const CommonTime& ttag,
                         const Triple& Vel, const Triple& Sig)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());
@@ -433,7 +433,7 @@ namespace gpstk
    // Add acceleration data (only) to the store
    void PositionSatStore::addAccelerationData(const SatID& sat,
                         const CommonTime& ttag, const Triple& Acc, const Triple& Sig)
-       throw(InvalidRequest)
+       noexcept(false)
    {
       try {
          checkTimeSystem(ttag.getTimeSystem());

--- a/core/lib/GNSSEph/PositionSatStore.hpp
+++ b/core/lib/GNSSEph/PositionSatStore.hpp
@@ -69,7 +69,7 @@ namespace gpstk
 
       /// Output stream operator is used by dump() in TabularSatStore
    std::ostream& operator<<(std::ostream& os, const PositionRecord& cdr)
-   throw();
+   noexcept;
 
       // This is a helper for SWIG processing - it needs a template
       // instation of the base type of PositionSatStore before it is
@@ -121,7 +121,7 @@ namespace gpstk
    public:
 
          /// Default constructor
-      PositionSatStore() throw()
+      PositionSatStore() noexcept
       : haveAcceleration(false), rejectBadPosFlag(true), Nhalf(5)
       {
          interpOrder = 2*Nhalf;
@@ -135,7 +135,7 @@ namespace gpstk
       ~PositionSatStore() {};
 
          /// Tabular does not have this...
-      bool hasAccleration() const throw() { return haveAcceleration; }
+      bool hasAccleration() const noexcept { return haveAcceleration; }
 
          /** Return value for the given satellite at the given time
           * (usually via interpolation of the data table). This
@@ -151,7 +151,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       PositionRecord getValue(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the position for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -165,7 +165,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       Triple getPosition(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the velocity for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -179,7 +179,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       Triple getVelocity(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the acceleration for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -195,7 +195,7 @@ namespace gpstk
           *     maxInterval
           *  d) neither velocity nor acceleration data are present */
       Triple getAcceleration(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Dump information about the object to an ostream.
           * @param[in] os ostream to receive the output; defaults to std::cout
@@ -205,7 +205,7 @@ namespace gpstk
           *           gap and interval flags and values, and file information
           *    1: number of data/sat
           *    2: above plus all the data tables */
-      virtual void dump(std::ostream& os = std::cout, int detail = 0) const throw()
+      virtual void dump(std::ostream& os = std::cout, int detail = 0) const noexcept
       {
          os << "Dump of PositionSatStore(" << detail << "):\n";
          os << " This store " << (haveAcceleration ? "contains":"does not contain")
@@ -226,30 +226,30 @@ namespace gpstk
           * different). */
       void addPositionRecord(const SatID& sat, const CommonTime& ttag,
                              const PositionRecord& rec)
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Add position data to the store; nothing else is changed
       void addPositionData(const SatID& sat, const CommonTime& ttag,
                            const Triple& Pos, const Triple& Sig=Triple())
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Add velocity data to the store; nothing else is changed
       void addVelocityData(const SatID& sat, const CommonTime& ttag,
                            const Triple& Vel, const Triple& Sig=Triple())
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Add acceleration data to the store; nothing else is changed
       void addAccelerationData(const SatID& sat, const CommonTime& ttag,
                                const Triple& Acc, const Triple& Sig=Triple())
-         throw(InvalidRequest);
+         noexcept(false);
 
          /// Get current interpolation order.
-      unsigned int getInterpolationOrder(void) const throw()
+      unsigned int getInterpolationOrder(void) const noexcept
       { return interpOrder; }
 
          /** Set the interpolation order; this routine forces the
           * order to be even. */
-      void setInterpolationOrder(unsigned int order) throw()
+      void setInterpolationOrder(unsigned int order) noexcept
       { Nhalf = (order+1)/2; interpOrder = 2*Nhalf; }
 
          /** Set the flag; if true then bad position values are

--- a/core/lib/GNSSEph/RationalizeRinexNav.cpp
+++ b/core/lib/GNSSEph/RationalizeRinexNav.cpp
@@ -134,7 +134,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void RationalizeRinexNav::rationalize()
-      throw(InvalidRequest)
+      noexcept(false)
    {
          // These items store the status of the most recently observed
          // upload cutover
@@ -634,7 +634,7 @@ namespace gpstk
 
    //----------------------------------------------------------------
    void RationalizeRinexNav::removeMisTaggedDataSets()
-         throw(InvalidRequest)
+         noexcept(false)
    {
          //  For each SV  
       SAT_NAV_DATA_LIST::iterator it1;

--- a/core/lib/GNSSEph/RationalizeRinexNav.hpp
+++ b/core/lib/GNSSEph/RationalizeRinexNav.hpp
@@ -94,7 +94,7 @@ namespace gpstk
          // that are labeled with the incorrect PRN.  Remove
          // such data sets.
       void removeMisTaggedDataSets()
-         throw(InvalidRequest);
+         noexcept(false);
 
          // Return a bit-encoded count of the number of 
          // parameters that are NOT equal.
@@ -104,7 +104,7 @@ namespace gpstk
          // Examine and stored data, fix the transmit times.
          // Throws an error if it encounters data that cannot be interpreted.
       void rationalize()
-         throw(InvalidRequest);
+         noexcept(false);
 
          // Dump summary of contents of store
       void dump(std::ostream& out=std::cout) const;

--- a/core/lib/GNSSEph/Rinex3EphemerisStore.cpp
+++ b/core/lib/GNSSEph/Rinex3EphemerisStore.cpp
@@ -299,7 +299,7 @@ namespace gpstk
 
 
    Xvt Rinex3EphemerisStore ::
-   computeXvt(const SatID& sat, const CommonTime& inttag) const throw()
+   computeXvt(const SatID& sat, const CommonTime& inttag) const noexcept
    {
       Xvt rv;
       rv.health = Xvt::HealthStatus::Unavailable;
@@ -343,7 +343,7 @@ namespace gpstk
 
 
    Xvt::HealthStatus Rinex3EphemerisStore ::
-   getSVHealth(const SatID& sat, const CommonTime& inttag) const throw()
+   getSVHealth(const SatID& sat, const CommonTime& inttag) const noexcept
    {
       Xvt::HealthStatus rv = Xvt::HealthStatus::Unavailable;
       try

--- a/core/lib/GNSSEph/Rinex3EphemerisStore.hpp
+++ b/core/lib/GNSSEph/Rinex3EphemerisStore.hpp
@@ -145,14 +145,14 @@ namespace gpstk
           * @param[in] t the time to look up
           * @return the Xvt of the object at the indicated time */
       virtual Xvt computeXvt(const SatID& id, const CommonTime& t) const
-         throw();
+         noexcept;
 
          /** Get the satellite health at a specific time.
           * @param[in] id the object's identifier
           * @param[in] t the time to look up
           * @return the health status of the object at the indicated time. */
       virtual Xvt::HealthStatus getSVHealth(const SatID& id,
-                                            const CommonTime& t) const throw();
+                                            const CommonTime& t) const noexcept;
 
          /** Dump information about the store to an ostream.
           * @param[in] os ostream to receive the output; defaults to std::cout

--- a/core/lib/GNSSEph/RinexEphemerisStore.cpp
+++ b/core/lib/GNSSEph/RinexEphemerisStore.cpp
@@ -52,7 +52,7 @@ namespace gpstk
    //-----------------------------------------------------------------------------
    //-----------------------------------------------------------------------------
    void RinexEphemerisStore::loadFile(const std::string& filename)
-      throw(FileMissingException)
+      noexcept(false)
    {
       try
       {
@@ -82,7 +82,7 @@ namespace gpstk
    //--------------------------------------------------------------------------
    //--------------------------------------------------------------------------
    void RinexEphemerisStore::dump(std::ostream& s, short detail)
-      const throw()
+      const noexcept
    {
       s << "Dump of RinexEphemerisStore:" << std::endl;
       std::vector<std::string> fileNames = getFileNames();

--- a/core/lib/GNSSEph/RinexEphemerisStore.hpp
+++ b/core/lib/GNSSEph/RinexEphemerisStore.hpp
@@ -61,7 +61,7 @@ namespace gpstk
    {
    public:
       RinexEphemerisStore()
-      throw()
+      noexcept
       { GPSEphemerisStore(); }
 
          /// destructor
@@ -75,11 +75,11 @@ namespace gpstk
           *   2 above, plus dump all the PVT data (use judiciously).
           */
       void dump(std::ostream& s=std::cout, short detail=0)
-         const throw();
+         const noexcept;
 
          /// load the given Rinex file
       void loadFile(const std::string& filename) 
-         throw(FileMissingException);
+         noexcept(false);
    };
 
       //@}

--- a/core/lib/GNSSEph/RinexObsID.cpp
+++ b/core/lib/GNSSEph/RinexObsID.cpp
@@ -46,7 +46,7 @@
 namespace gpstk
 {
    /// Construct this object from the string specifier
-   RinexObsID::RinexObsID(const std::string& strID) throw(InvalidParameter)
+   RinexObsID::RinexObsID(const std::string& strID) noexcept(false)
    {
       if(!isValidRinexObsID(strID)) {
          InvalidParameter ip(strID + " is not a valid RinexObsID");
@@ -174,7 +174,7 @@ namespace gpstk
       return true;
    }
 
-   std::ostream& RinexObsID::dumpCheck(std::ostream& s) throw(Exception)
+   std::ostream& RinexObsID::dumpCheck(std::ostream& s) noexcept(false)
    {
       try {
          const std::string types("CLDS");

--- a/core/lib/GNSSEph/RinexObsID.hpp
+++ b/core/lib/GNSSEph/RinexObsID.hpp
@@ -107,10 +107,10 @@ namespace gpstk
             : ObsID(ot, cb, tc) {};
       
          /// Construct this object from the string specifier
-      RinexObsID(const std::string& strID) throw(InvalidParameter);
+      RinexObsID(const std::string& strID) noexcept(false);
 
          /// Constructor from ObsID
-      RinexObsID(const ObsID& oid) throw(InvalidParameter)
+      RinexObsID(const ObsID& oid) noexcept(false)
       {
          type=oid.type; band=oid.band; code=oid.code;
          std::string str(this->asString());
@@ -144,7 +144,7 @@ namespace gpstk
          //static std::string validRinexSystems;
 
       static std::ostream& dumpCheck(std::ostream& s)
-         throw(gpstk::Exception);
+         noexcept(false);
 
    }; // end class RinexObsID
 

--- a/core/lib/GNSSEph/RinexSatID.hpp
+++ b/core/lib/GNSSEph/RinexSatID.hpp
@@ -65,14 +65,14 @@ namespace gpstk
          /// Empty constructor; creates an invalid object (Unknown, ID = -1).
 
       RinexSatID()
-      throw()
+      noexcept
       { id = -1; system = systemUnknown; }
 
 
          /// Explicit constructor, no defaults, RINEX systems only.
 
       RinexSatID(int p, const SatelliteSystem& s)
-         throw()
+         noexcept
       {
          id = p; system = s;
          switch(s)
@@ -98,7 +98,7 @@ namespace gpstk
          /// Constructor from a string.
 
       RinexSatID(const std::string& str)
-         throw(Exception)
+         noexcept(false)
       {
          try { fromString(str); }
          catch(Exception& e) { GPSTK_RETHROW(e); }
@@ -108,7 +108,7 @@ namespace gpstk
          /// Cast a SatID to a RinexSatID.
 
       RinexSatID(const SatID& sat)
-         throw()
+         noexcept
       { *this = RinexSatID(sat.id,sat.system); }
 
 
@@ -116,14 +116,14 @@ namespace gpstk
          /// return the current fill character.
 
       char setfill(char c)
-         throw()
+         noexcept
       { char csave = fillchar; fillchar = c; return csave; }
 
 
          /// Get the fill character used in output.
 
       char getfill() const
-         throw()
+         noexcept
       { return fillchar; }
 
 
@@ -134,7 +134,7 @@ namespace gpstk
          /// @note return only RINEX types, for non-RINEX systems return '?'
 
       char systemChar() const
-         throw()
+         noexcept
       {
          switch(system)
          {
@@ -154,7 +154,7 @@ namespace gpstk
          /// Return the system name as a string.
          /// @note Return only RINEX types or 'Unknown'.
       std::string systemString() const
-         throw()
+         noexcept
       {
          switch(system)
          {
@@ -173,7 +173,7 @@ namespace gpstk
          /// Return the system name as a string of length 3.
          /// @note Return only RINEX types or 'Unknown'.
       std::string systemString3() const
-         throw()
+         noexcept
       {
          switch(system)
          {
@@ -194,7 +194,7 @@ namespace gpstk
          /// @note GPS is default system (no or unknown system char)
 
       void fromString(const std::string& s)
-         throw(Exception)
+         noexcept(false)
       {
          char c;
          std::istringstream iss(s);
@@ -252,7 +252,7 @@ namespace gpstk
          /// Convert the RinexSatID to string (1 character plus 2-digit integer).
 
       std::string toString() const
-         throw()
+         noexcept
       {
          std::ostringstream oss;
          oss.fill(fillchar);

--- a/core/lib/GNSSEph/SP3EphemerisStore.cpp
+++ b/core/lib/GNSSEph/SP3EphemerisStore.cpp
@@ -79,7 +79,7 @@ namespace gpstk
       //    reason, this is thrown. The text may have additional
       //    information as to why the request failed.
    Xvt SP3EphemerisStore::getXvt(const SatID& sat, const CommonTime& ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       PositionRecord prec;
       ClockRecord crec;
@@ -114,7 +114,7 @@ namespace gpstk
 
 
    Xvt SP3EphemerisStore::computeXvt(const SatID& sat, const CommonTime& ttag)
-      const throw()
+      const noexcept
    {
       Xvt rv;
       rv.health = Xvt::HealthStatus::Unavailable;
@@ -167,7 +167,7 @@ namespace gpstk
 
 
    Xvt::HealthStatus SP3EphemerisStore ::
-   getSVHealth(const SatID& sat, const CommonTime& ttag) const throw()
+   getSVHealth(const SatID& sat, const CommonTime& ttag) const noexcept
    {
          // health information is not available in SP3
       return Xvt::HealthStatus::Unused;
@@ -177,7 +177,7 @@ namespace gpstk
       // determine the Xvt for any object.
       // return the earliest time in the table
       // throw InvalidRequest if there is no data.
-   CommonTime SP3EphemerisStore::getInitialTime() const throw(InvalidRequest)
+   CommonTime SP3EphemerisStore::getInitialTime() const noexcept(false)
    {
       try {
          if(useSP3clock) return posStore.getInitialTime();
@@ -196,7 +196,7 @@ namespace gpstk
       // determine the Xvt for any object.
       // return the latest time in the table
       // throw InvalidRequest if there is no data.
-   CommonTime SP3EphemerisStore::getFinalTime() const throw(InvalidRequest)
+   CommonTime SP3EphemerisStore::getFinalTime() const noexcept(false)
    {
       try {
          if(useSP3clock) return posStore.getFinalTime();
@@ -222,7 +222,7 @@ namespace gpstk
       //  b) checkDataGap is true and there is a data gap
       //  c) checkInterval is true and the interval is larger than maxInterval
    Triple SP3EphemerisStore::getPosition(const SatID sat, const CommonTime ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          PositionRecord prec;
@@ -243,7 +243,7 @@ namespace gpstk
       //  b) checkDataGap is true and there is a data gap
       //  c) checkInterval is true and the interval is larger than maxInterval
    Triple SP3EphemerisStore::getVelocity(const SatID sat, const CommonTime ttag)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          PositionRecord prec;
@@ -258,7 +258,7 @@ namespace gpstk
       // Get the earliest time of data in the store for the given satellite.
       // Return the first time
    CommonTime SP3EphemerisStore::getInitialTime(const SatID& sat)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          if(useSP3clock) return posStore.getInitialTime(sat);
@@ -277,7 +277,7 @@ namespace gpstk
       // Return the latest time
       // Throw InvalidRequest if there is no data
    CommonTime SP3EphemerisStore::getFinalTime(const SatID& sat)
-      const throw(InvalidRequest)
+      const noexcept(false)
    {
       try {
          if(useSP3clock) return posStore.getFinalTime(sat);
@@ -297,7 +297,7 @@ namespace gpstk
       // Store position (velocity) and clock data from SP3 files in clock and position
       // stores. Also update the FileStore with the filename and SP3 header.
    void SP3EphemerisStore::loadSP3Store(const string& filename, bool fillClockStore)
-      throw(Exception)
+      noexcept(false)
    {
       try
       {
@@ -609,7 +609,7 @@ namespace gpstk
       // this routine will also accept that file type and load the data into the
       // clock store. This routine will may set the velocity, acceleration, bias
       // or drift 'have' flags.
-   void SP3EphemerisStore::loadFile(const string& filename) throw(Exception)
+   void SP3EphemerisStore::loadFile(const string& filename) noexcept(false)
    {
       try
       {
@@ -657,7 +657,7 @@ namespace gpstk
       // Load an SP3 ephemeris file; may set the velocity and acceleration flags.
       // If the clock store uses RINEX clock files, this ignores the clock data.
    void SP3EphemerisStore::loadSP3File(const std::string& filename)
-      throw(Exception)
+      noexcept(false)
    {
       try
       {
@@ -671,7 +671,7 @@ namespace gpstk
 
       // Load a RINEX clock file; may set the 'have' bias and drift flags
    void SP3EphemerisStore::loadRinexClockFile(const std::string& filename)
-      throw(Exception)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/GNSSEph/SP3EphemerisStore.hpp
+++ b/core/lib/GNSSEph/SP3EphemerisStore.hpp
@@ -130,12 +130,12 @@ namespace gpstk
          * Check time systems consistentcy, and if possible set store
          * time system. */
       void loadSP3Store(const std::string& filename, bool fillClockStore)
-         throw(Exception);
+         noexcept(false);
 
    public:
 
          /// Default constructor
-      SP3EphemerisStore() throw() : storeTimeSystem(TimeSystem::Any),
+      SP3EphemerisStore() noexcept : storeTimeSystem(TimeSystem::Any),
          useSP3clock(true),
          rejectBadPosFlag(true),
          rejectBadClockFlag(true),
@@ -158,7 +158,7 @@ namespace gpstk
           *    reason, this is thrown. The text may have additional
           *    information as to why the request failed. */
       virtual Xvt getXvt(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Compute the position, velocity and clock offset of the
           * indicated object in ECEF coordinates (meters) at the
@@ -180,7 +180,7 @@ namespace gpstk
           * @param[in] t the time to look up
           * @return the Xvt of the object at the indicated time */
       virtual Xvt computeXvt(const SatID& id, const CommonTime& t) const
-         throw();
+         noexcept;
 
          /** Get the satellite health at a specific time.
           * @param[in] id the object's identifier
@@ -188,7 +188,7 @@ namespace gpstk
           * @return "Unused" at all times as the SP3 format does not
           *   provide health status. */
       virtual Xvt::HealthStatus getSVHealth(const SatID& id,
-                                            const CommonTime& t) const throw();
+                                            const CommonTime& t) const noexcept;
 
          /** Dump information about the store to an ostream.
           * @param[in] os ostream to receive the output; defaults to std::cout
@@ -199,7 +199,7 @@ namespace gpstk
           *       number of data/sat
           *    2: above plus all the data tables */
       virtual void dump(std::ostream& os = std::cout, short detail = 0)
-         const throw()
+         const noexcept
       {
             // may have to re-write this...
          os << "Dump SP3EphemerisStore:" << std::endl;
@@ -226,38 +226,38 @@ namespace gpstk
           * @param[in] tmin defines the beginning of the time interval
           * @param[in] tmax defines the end of the time interval */
       virtual void edit(const CommonTime& tmin, 
-                        const CommonTime& tmax = CommonTime::END_OF_TIME) throw()
+                        const CommonTime& tmax = CommonTime::END_OF_TIME) noexcept
       {
          posStore.edit(tmin, tmax);
          clkStore.edit(tmin, tmax);
       }
 
          /// Clear the dataset, meaning remove all data
-      virtual void clear(void) throw()
+      virtual void clear(void) noexcept
       { clearPosition(); clearClock(); }
  
          /// Return time system (@note usually GPS, but CANNOT assume so)
-      virtual TimeSystem getTimeSystem(void) const throw()
+      virtual TimeSystem getTimeSystem(void) const noexcept
       { return storeTimeSystem; }
 
          /** Determine the earliest time for which this object can
           * successfully determine the Xvt for any object.
           * @return the earliest time in the table
           * @throw InvalidRequest if the object has no data. */
-      virtual CommonTime getInitialTime() const throw(InvalidRequest);
+      virtual CommonTime getInitialTime() const noexcept(false);
 
          /** Determine the latest time for which this object can
           * successfully determine the Xvt for any object.
           * @return the latest time in the table
           * @throw InvalidRequest if the object has no data. */
-      virtual CommonTime getFinalTime() const throw(InvalidRequest);
+      virtual CommonTime getFinalTime() const noexcept(false);
 
          /// Return true if IndexType=SatID is present in the data tables
-      virtual bool isPresent(const SatID& sat) const throw()
+      virtual bool isPresent(const SatID& sat) const noexcept
       { return (posStore.isPresent(sat) && clkStore.isPresent(sat)); }
 
          /// Return true if velocity is present in the data tables
-      virtual bool hasVelocity() const throw()
+      virtual bool hasVelocity() const noexcept
       {  return posStore.hasVelocity(); }
 
          // end of XvtStore interface
@@ -271,7 +271,7 @@ namespace gpstk
           *       number of data/sat
           *    2: above plus all the data tables */
       void dumpPosition(std::ostream& os = std::cout, short detail = 0)
-         const throw()
+         const noexcept
       {
          SP3Files.dump(os, detail);
          posStore.dump(os, detail);
@@ -286,7 +286,7 @@ namespace gpstk
           *       number of data/sat
           *    2: above plus all the data tables */
       void dumpClock(std::ostream& os = std::cout, short detail = 0)
-         const throw()
+         const noexcept
       {
          if(useSP3clock)
             SP3Files.dump(os, detail);
@@ -307,7 +307,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       Triple getPosition(const SatID sat, const CommonTime ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the velocity for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -321,7 +321,7 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       Triple getVelocity(const SatID sat, const CommonTime ttag)
-         const throw(InvalidRequest);
+         const noexcept(false);
 
          /** Return the acceleration for the given satellite at the given time
           * @param[in] sat the SatID of the satellite of interest
@@ -336,18 +336,18 @@ namespace gpstk
           *  c) checkInterval is true and the interval is larger than
           *     maxInterval */
       Triple getAcceleration(const SatID sat, const CommonTime ttag)
-         const throw(InvalidRequest)
+         const noexcept(false)
       { return posStore.getAcceleration(sat,ttag); }
 
 
          /** Clear the position dataset only, meaning remove all data
           * from the tables. */
-      virtual void clearPosition(void) throw()
+      virtual void clearPosition(void) noexcept
       { posStore.clear(); }
 
          /** Clear the clock dataset only, meaning remove all data
           * from the tables. */
-      virtual void clearClock(void) throw()
+      virtual void clearClock(void) noexcept
       { clkStore.clear(); }
 
    
@@ -359,7 +359,7 @@ namespace gpstk
           * RINEX clock.
           * @note will be called by loadRinexClockFile() if clock
           * store is set to SP3. */
-      void useRinexClockData(void) throw()
+      void useRinexClockData(void) noexcept
       {
          if(!useSP3clock) return;
          useSP3clock = false;
@@ -375,7 +375,7 @@ namespace gpstk
          * @note this will also load position data into the position
          * store.  This routine has no effect if the clock store is
          * already set to SP3. */
-      void useSP3ClockData(void) throw()
+      void useSP3ClockData(void) noexcept
       {
          if(useSP3clock) return;
          useSP3clock = true;
@@ -385,25 +385,25 @@ namespace gpstk
          /** Get the earliest time of data in the position store.
           * @return CommonTime the first time
           * @throw InvalidRequest if there is no data */
-      CommonTime getPositionInitialTime(void) const throw(InvalidRequest)
+      CommonTime getPositionInitialTime(void) const noexcept(false)
       { return posStore.getInitialTime(); }
 
          /** Get the latest time of data in the position store.
           * @return CommonTime the latest time
           * @throw InvalidRequest if there is no data */
-      CommonTime getPositionFinalTime(void) const throw(InvalidRequest)
+      CommonTime getPositionFinalTime(void) const noexcept(false)
       { return posStore.getFinalTime(); }
 
          /** Get the earliest time of data in the clock store.
           * @return CommonTime the first time
           * @throw InvalidRequest if there is no data */
-      CommonTime getClockInitialTime(void) const throw(InvalidRequest)
+      CommonTime getClockInitialTime(void) const noexcept(false)
       { return clkStore.getInitialTime(); }
 
          /** Get the latest time of data in the clock store.
           * @return CommonTime the latest time
           * @throw InvalidRequest if there is no data */
-      CommonTime getClockFinalTime(void) const throw(InvalidRequest)
+      CommonTime getClockFinalTime(void) const noexcept(false)
       { return clkStore.getFinalTime(); }
 
          /** Get the earliest time of data in the position store for
@@ -411,7 +411,7 @@ namespace gpstk
           * @return CommonTime the first time
           * @throw InvalidRequest if there is no data */
       CommonTime getPositionInitialTime(const SatID& sat) const
-         throw(InvalidRequest)
+         noexcept(false)
       { return posStore.getInitialTime(sat); }
 
          /** Get the latest time of data in the position store for the
@@ -419,7 +419,7 @@ namespace gpstk
           * @return CommonTime the latest time
           * @throw InvalidRequest if there is no data */
       CommonTime getPositionFinalTime(const SatID& sat) const
-         throw(InvalidRequest)
+         noexcept(false)
       { return posStore.getFinalTime(sat); }
 
          /** Get the earliest time of data in the clock store for the
@@ -427,7 +427,7 @@ namespace gpstk
           * @return CommonTime the first time
           * @throw InvalidRequest if there is no data */
       CommonTime getClockInitialTime(const SatID& sat) const
-         throw(InvalidRequest)
+         noexcept(false)
       { return clkStore.getInitialTime(sat); }
 
          /** Get the latest time of data in the clock store for the
@@ -435,68 +435,68 @@ namespace gpstk
           * @return CommonTime the latest time
           * @throw InvalidRequest if there is no data */
       CommonTime getClockFinalTime(const SatID& sat) const
-         throw(InvalidRequest)
+         noexcept(false)
       { return clkStore.getFinalTime(sat); }
 
          /** Get the earliest time of both clock and position data in
          * the store for the given satellite.
          * @return CommonTime the first time
          * @throw InvalidRequest if there is no data */
-      CommonTime getInitialTime(const SatID& sat) const throw(InvalidRequest);
+      CommonTime getInitialTime(const SatID& sat) const noexcept(false);
 
          /** Get the latest time of both clock and position data in
           * the store for the given satellite.
           * @return the latest time
           * @throw InvalidRequest if there is no data */
-      CommonTime getFinalTime(const SatID& sat) const throw(InvalidRequest);
+      CommonTime getFinalTime(const SatID& sat) const noexcept(false);
 
 
          /** Get the nominal time step in seconds for the position
           * data and the given sat */
-      double getPositionTimeStep(const SatID& sat) const throw()
+      double getPositionTimeStep(const SatID& sat) const noexcept
       { return posStore.nomTimeStep(sat); }
 
          /** Get the nominal time step in seconds for the clock data
           * and the given sat */
-      double getClockTimeStep(const SatID& sat) const throw()
+      double getClockTimeStep(const SatID& sat) const noexcept
       { return clkStore.nomTimeStep(sat); }
 
 
          /// Get current interpolation order for the position table
-      unsigned int getPositionInterpOrder(void) const throw()
+      unsigned int getPositionInterpOrder(void) const noexcept
       { return posStore.getInterpolationOrder(); }
 
          /** Set the interpolation order for the position table; it is
           * forced to be even. */
-      void setPositionInterpOrder(unsigned int order) throw()
+      void setPositionInterpOrder(unsigned int order) noexcept
       { posStore.setInterpolationOrder(order); }
 
          /** Get current interpolation order for the clock data
           * (meaningless if the interpolation type is linear). */
-      unsigned int getClockInterpOrder(void) throw()
+      unsigned int getClockInterpOrder(void) noexcept
       { return clkStore.getInterpolationOrder(); }
 
          /** Set the interpolation order for the clock table; it is
           * forced to be even.  This is ignored if the clock
           * interpolation type is linear. */
-      void setClockInterpOrder(unsigned int order) throw()
+      void setClockInterpOrder(unsigned int order) noexcept
       { clkStore.setInterpolationOrder(order); }
 
          /** Set the type of clock interpolation to Lagrange (the
           * default); set the order of the interpolation with
           * setClockInterpolationOrder(order); */
-      void setClockLagrangeInterp(void) throw()
+      void setClockLagrangeInterp(void) noexcept
       { clkStore.setLagrangeInterp(); }
 
          /** Set the type of clock interpolation to linear
           * (interpolation order is ignored). */
-      void setClockLinearInterp(void) throw()
+      void setClockLinearInterp(void) noexcept
       { clkStore.setLinearInterp(); }
 
 
          /** Get a list (std::vector) of SatIDs present in both clock
           * and position stores */
-      std::vector<SatID> getSatList(void) const throw()
+      std::vector<SatID> getSatList(void) const noexcept
       {
          std::vector<SatID> posList(posStore.getSatList());
          std::vector<SatID> clkList(clkStore.getSatList());
@@ -527,55 +527,55 @@ namespace gpstk
       }
 
          /// Get a list (std::vector) of SatIDs present in the position store
-      std::vector<SatID> getPositionSatList(void) const throw()
+      std::vector<SatID> getPositionSatList(void) const noexcept
       { return posStore.getSatList(); }
 
          /// Get a list (std::vector) of SatIDs present in the clock store
-      std::vector<SatID> getClockSatList(void) const throw()
+      std::vector<SatID> getClockSatList(void) const noexcept
       { return clkStore.getSatList(); }
 
 
          /// Get the total number of (position) data records in the store
-      inline int ndata(void) const throw()
+      inline int ndata(void) const noexcept
       { return posStore.ndata(); }
 
          /// Get the number of (position) data records for the given sat
-      inline int ndata(const SatID& sat) const throw()
+      inline int ndata(const SatID& sat) const noexcept
       { return posStore.ndata(sat); }
 
          /** Get the number of (position) data records for the given
           * satellite system */
-      inline int ndata(const SatID::SatelliteSystem& sys) const throw()
+      inline int ndata(const SatID::SatelliteSystem& sys) const noexcept
       { return posStore.ndata(sys); }
 
          /// Get the total number of position data records in the store
-      inline int ndataPosition(void) const throw()
+      inline int ndataPosition(void) const noexcept
       { return posStore.ndata(); }
 
          /// Get the number of position data records for the given sat
-      inline int ndataPosition(const SatID& sat) const throw()
+      inline int ndataPosition(const SatID& sat) const noexcept
       { return posStore.ndata(sat); }
 
          /** Get the number of position data records for the given
           * satellite system */
-      inline int ndataPosition(const SatID::SatelliteSystem& sys) const throw()
+      inline int ndataPosition(const SatID::SatelliteSystem& sys) const noexcept
       { return posStore.ndata(sys); }
 
          /// Get the total number of clock data records in the store
-      inline int ndataClock(void) const throw()
+      inline int ndataClock(void) const noexcept
       { return clkStore.ndata(); }
 
          /// Get the number of clock data records for the given sat
-      inline int ndataClock(const SatID& sat) const throw()
+      inline int ndataClock(const SatID& sat) const noexcept
       { return clkStore.ndata(sat); }
 
          /** Get the number of clock data records for the given
           * satellite system */
-      inline int ndataClock(const SatID::SatelliteSystem& sys) const throw()
+      inline int ndataClock(const SatID::SatelliteSystem& sys) const noexcept
       { return clkStore.ndata(sys); }
 
          /// same as ndataPosition()
-      inline int size(void) const throw() { return ndataPosition(); }
+      inline int size(void) const noexcept { return ndataPosition(); }
 
 
          /** Load an SP3 ephemeris file; if the clock store uses RINEX
@@ -585,21 +585,21 @@ namespace gpstk
           * flags.
           * @param filename name of file (SP3 or RINEX clock format) to load 
           * @throw if time step is inconsistent with previous value */
-      void loadFile(const std::string& filename) throw(Exception);
+      void loadFile(const std::string& filename) noexcept(false);
 
          /** Load an SP3 ephemeris file; may set the velocity and
           * acceleration flags.  If the clock store uses RINEX clock
           * data, this will ignore the clock data.
           * @param filename name of file (SP3 format) to load 
           * @throw if time step is inconsistent with previous value */
-      void loadSP3File(const std::string& filename) throw(Exception);
+      void loadSP3File(const std::string& filename) noexcept(false);
 
          /** Load a RINEX clock file; may set the 'have' bias and
           * drift flags.  If clock store is set to use SP3 data, this
           * will call useRinexClockData()
           * @param filename name of file (RINEX clock format) to load 
           * @throw if time step is inconsistent with previous value */
-      void loadRinexClockFile(const std::string& filename) throw(Exception);
+      void loadRinexClockFile(const std::string& filename) noexcept(false);
 
 
          /** Add a complete PositionRecord to the store; this is the
@@ -611,7 +611,7 @@ namespace gpstk
           * cause the std::map to consider two "equal" ttags as
           * different). */
       void addPositionRecord(const SatID& sat, const CommonTime& ttag,
-                             const PositionRecord& data) throw(InvalidRequest)
+                             const PositionRecord& data) noexcept(false)
       {
          try { posStore.addPositionRecord(sat,ttag,data); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -619,7 +619,7 @@ namespace gpstk
 
          /// Add position data to the store
       void addPositionData(const SatID& sat, const CommonTime& ttag,
-                           const Triple& Pos, const Triple& sig) throw(InvalidRequest)
+                           const Triple& Pos, const Triple& sig) noexcept(false)
       {
          try { posStore.addPositionData(sat,ttag,Pos,sig); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -627,7 +627,7 @@ namespace gpstk
 
          /// Add velocity data to the store
       void addVelocityData(const SatID& sat, const CommonTime& ttag,
-                           const Triple& Vel, const Triple& sig) throw(InvalidRequest)
+                           const Triple& Vel, const Triple& sig) noexcept(false)
       {
          try { posStore.addVelocityData(sat,ttag,Vel,sig); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -643,7 +643,7 @@ namespace gpstk
           * different). */
       void addClockRecord(const SatID& sat, const CommonTime& ttag,
                           const ClockRecord& rec)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try { clkStore.addClockRecord(sat,ttag,rec); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -652,7 +652,7 @@ namespace gpstk
          /// Add clock bias data (only) to the store
       void addClockBias(const SatID& sat, const CommonTime& ttag,
                         const double& bias, const double& sig=0.0)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try { clkStore.addClockBias(sat,ttag,bias,sig); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -661,7 +661,7 @@ namespace gpstk
          /// Add clock drift data (only) to the store
       void addClockDrift(const SatID& sat, const CommonTime& ttag,
                          const double& drift, const double& sig=0.0)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try { clkStore.addClockDrift(sat,ttag,drift,sig); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -670,7 +670,7 @@ namespace gpstk
          /// Add clock acceleration data (only) to the store
       void addClockAcceleration(const SatID& sat, const CommonTime& ttag,
                                 const double& accel, const double& sig=0.0)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try { clkStore.addClockAcceleration(sat,ttag,accel,sig); }
          catch(InvalidRequest& ir) { GPSTK_RETHROW(ir); }
@@ -678,20 +678,20 @@ namespace gpstk
 
 
          /// Get number of files (all types) in FileStore.
-      int nfiles(void) throw()
+      int nfiles(void) noexcept
       { return (SP3Files.size() + (useSP3clock ? 0 : clkFiles.size())); }
 
          /// Get number of SP3 files in FileStore.
-      int nSP3files(void) throw()
+      int nSP3files(void) noexcept
       { return SP3Files.size(); }
 
          /// Get number of clock files in FileStore.
-      int nClockfiles(void) throw()
+      int nClockfiles(void) noexcept
       { return (useSP3clock ? SP3Files.size() : clkFiles.size()); }
 
 
          /// Return true if there is drift data in the tables
-      virtual bool hasClockDrift() const throw()
+      virtual bool hasClockDrift() const noexcept
       {  return clkStore.hasClockDrift(); }
 
 
@@ -718,100 +718,100 @@ namespace gpstk
 
 
          /// Is gap checking for position on?
-      bool isPosDataGapCheck(void) throw()
+      bool isPosDataGapCheck(void) noexcept
       { return posStore.isDataGapCheck(); }
 
          /// Is gap checking for clock on?
-      bool isClkDataGapCheck(void) throw()
+      bool isClkDataGapCheck(void) noexcept
       { return clkStore.isDataGapCheck(); }
 
          /// Disable checking of data gaps in both position and clock.
-      void disableDataGapCheck(void) throw()
+      void disableDataGapCheck(void) noexcept
       { posStore.disableDataGapCheck(); clkStore.disableDataGapCheck(); }
 
          /// Disable checking of data gaps in position store
-      void disablePosDataGapCheck(void) throw()
+      void disablePosDataGapCheck(void) noexcept
       { posStore.disableDataGapCheck(); }
 
          /// Disable checking of data gaps in clock store
-      void disableClockDataGapCheck(void) throw()
+      void disableClockDataGapCheck(void) noexcept
       { clkStore.disableDataGapCheck(); }
 
          /// Get current gap interval in the position store.
-      double getPosGapInterval(void) throw()
+      double getPosGapInterval(void) noexcept
       { return posStore.getGapInterval(); }
 
          /// Get current gap interval in the clock store.
-      double getClockGapInterval(void) throw()
+      double getClockGapInterval(void) noexcept
       { return clkStore.getGapInterval(); }
 
          /** Set gap interval and turn on gap checking in the position
           * store. There is no default. */
-      void setPosGapInterval(double interval) throw()
+      void setPosGapInterval(double interval) noexcept
       { posStore.setGapInterval(interval); }
 
          /** Set gap interval and turn on gap checking in the clock
           * store.  There is no default. */
-      void setClockGapInterval(double interval) throw()
+      void setClockGapInterval(double interval) noexcept
       { clkStore.setGapInterval(interval); }
 
 
          /// Is interval checking for position on?
-      bool isPosIntervalCheck(void) throw()
+      bool isPosIntervalCheck(void) noexcept
       { return posStore.isIntervalCheck(); }
 
          /// Is interval checking for clock on?
-      bool isClkIntervalCheck(void) throw()
+      bool isClkIntervalCheck(void) noexcept
       { return clkStore.isIntervalCheck(); }
 
          /// Disable checking of maximum interval in both position and clock.
-      void disableIntervalCheck(void) throw()
+      void disableIntervalCheck(void) noexcept
       { posStore.disableIntervalCheck(); clkStore.disableIntervalCheck(); }
 
          /// Disable checking of maximum interval in position store
-      void disablePosIntervalCheck(void) throw()
+      void disablePosIntervalCheck(void) noexcept
       { posStore.disableIntervalCheck(); }
 
          /// Disable checking of maximum interval in clock store
-      void disableClockIntervalCheck(void) throw()
+      void disableClockIntervalCheck(void) noexcept
       { clkStore.disableIntervalCheck(); }
 
          /// Get current maximum interval in the position store
-      double getPosMaxInterval(void) throw()
+      double getPosMaxInterval(void) noexcept
       { return posStore.getMaxInterval(); }
 
          /// Get current maximum interval in the clock store
-      double getClockMaxInterval(void) throw()
+      double getClockMaxInterval(void) noexcept
       { return clkStore.getMaxInterval(); }
 
          /** Set maximum interval and turn on interval checking in the
           * position store There is no default. */
-      void setPosMaxInterval(double interval) throw()
+      void setPosMaxInterval(double interval) noexcept
       { posStore.setMaxInterval(interval); }
 
          /** Set maximum interval and turn on interval checking in the
           * clock store There is no default. */
-      void setClockMaxInterval(double interval) throw()
+      void setClockMaxInterval(double interval) noexcept
       { clkStore.setMaxInterval(interval); }
 
 
          /// @deprecated
-      virtual bool velocityIsPresent() const throw()
+      virtual bool velocityIsPresent() const noexcept
       { return posStore.hasVelocity(); }
 
          /// @deprecated
-      virtual bool clockIsPresent() const throw()
+      virtual bool clockIsPresent() const noexcept
       { return true; }
 
          /** @deprecated
           * Get current (position) interpolation order */
-      unsigned int getInterpolationOrder(void) throw()
+      unsigned int getInterpolationOrder(void) noexcept
       { return getPositionInterpOrder(); }
 
          /** @deprecated
           * Set the (position) interpolation order for the position table;
           * it is forced to be even. */
-      void setInterpolationOrder(unsigned int order) throw()
+      void setInterpolationOrder(unsigned int order) noexcept
       { setPositionInterpOrder(order); }
 
    }; // end class SP3EphemerisStore

--- a/core/lib/GNSSEph/SP3SatID.hpp
+++ b/core/lib/GNSSEph/SP3SatID.hpp
@@ -62,10 +62,10 @@ namespace gpstk
    public:
 
          /// empty constructor, creates an invalid object
-      SP3SatID() throw() { id=-1; system=systemGPS; }
+      SP3SatID() noexcept { id=-1; system=systemGPS; }
 
          /// explicit constructor, no defaults, SP3 systems only
-      SP3SatID(int p, SatelliteSystem s) throw()
+      SP3SatID(int p, SatelliteSystem s) noexcept
       {
          id = p; system = s;
          switch(system) {
@@ -84,23 +84,23 @@ namespace gpstk
       }
 
          /// constructor from string
-      SP3SatID(const std::string& str) throw(Exception)
+      SP3SatID(const std::string& str) noexcept(false)
       {
          try { fromString(str); }
          catch(Exception& e) { GPSTK_RETHROW(e); }
       }
 
          /// cast SatID to SP3SatID
-      SP3SatID(const SatID& sat) throw()
+      SP3SatID(const SatID& sat) noexcept
       { *this = SP3SatID(sat.id,sat.system); }
 
          /// set the fill character used in output
          /// return the current fill character
-      char setfill(char c) throw()
+      char setfill(char c) noexcept
       { char csave=fillchar; fillchar=c; return csave; }
 
          /// get the fill character used in output
-      char getfill() throw()
+      char getfill() noexcept
       { return fillchar; }
 
          // operator=, copy constructor and destructor built by compiler
@@ -146,7 +146,7 @@ namespace gpstk
          /// return a character based on the system
          /// return the single-character system descriptor
          /// @note return only SP3 types, for non-SP3 systems return '?'
-      char systemChar() const throw()
+      char systemChar() const noexcept
       {
          switch (system) {
             case systemGPS:     return 'G';
@@ -161,7 +161,7 @@ namespace gpstk
          }
       };
 
-      std::string systemString() const throw()
+      std::string systemString() const noexcept
       {
          switch (system) {
             case systemGPS:     return "GPS";
@@ -177,7 +177,7 @@ namespace gpstk
 
          /// read from string
          /// @note GPS is default system (no or unknown system char)
-      void fromString(const std::string s) throw(Exception)
+      void fromString(const std::string s) noexcept(false)
       {
          char c;
          std::istringstream iss(s);
@@ -226,7 +226,7 @@ namespace gpstk
       }
 
          /// convert to string
-      std::string toString() const throw()
+      std::string toString() const noexcept
       {
          std::ostringstream oss;
          oss.fill(fillchar);

--- a/core/lib/GNSSEph/TabularSatStore.hpp
+++ b/core/lib/GNSSEph/TabularSatStore.hpp
@@ -131,7 +131,7 @@ namespace gpstk
          // member functions
    public:
          /// Default constructor
-      TabularSatStore() throw()
+      TabularSatStore() noexcept
       : storeTimeSystem(TimeSystem::Any),
          havePosition(false), haveVelocity(false),
          haveClockBias(false), haveClockDrift(false),
@@ -156,21 +156,21 @@ namespace gpstk
           *
           * Derived objects can implement similar routines, for example:
           * Triple getPosition(const SatID& sat, const CommonTime& t)
-          *    throw(InvalidRequest);
+          *    noexcept(false);
           * Triple getVelocity(const SatID& sat, const CommonTime& t)
-          *    throw(InvalidRequest);
+          *    noexcept(false);
           * Triple getAccel(const SatID& sat, const CommonTime& t)
-          *    throw(InvalidRequest);
+          *    noexcept(false);
           * double getClockBias(const SatID& s, const CommonTime& t)
-          *    throw(InvalidRequest);
+          *    noexcept(false);
           * double[2] getClock(const SatID& sat, const CommonTime& t)
-          *    throw(InvalidRequest);
+          *    noexcept(false);
           * @note Xvt getXvt(const SatID& sat, const CommonTime& t)
-          *    throw(InvalidRequest);
+          *    noexcept(false);
           *   will be provided by another class which inherits this one.
           */
       virtual DataRecord getValue(const SatID& sat, const CommonTime& ttag)
-         const throw(InvalidRequest) = 0;
+         const noexcept(false) = 0;
 
          /** Locate the given time in the DataTable for the given
           * satellite.  Return two const iterators it1 and it2
@@ -213,7 +213,7 @@ namespace gpstk
                                     typename DataTable::const_iterator& it1,
                                     typename DataTable::const_iterator& it2,
                                     bool exactReturn=true)
-         const throw(InvalidRequest)
+         const noexcept(false)
       {
          try
          {
@@ -419,7 +419,7 @@ namespace gpstk
                                                typename DataTable::const_iterator& it1,
                                                typename DataTable::const_iterator& it2,
                                                bool exactReturn=true)
-         const throw(InvalidRequest)
+         const noexcept(false)
       {
          try
          {
@@ -572,7 +572,7 @@ namespace gpstk
           *    1: number of data/sat
           *    2: above plus all the data tables */
       virtual void dump(std::ostream& os = std::cout, int detail = 0) const
-         throw()
+         noexcept
       {
          os << " Dump of TabularSatStore(" << detail << "):" << std::endl;
          if(detail >= 0)
@@ -649,7 +649,7 @@ namespace gpstk
           * @param[in] tmax defines the end of the time interval */
       void edit(const CommonTime& tmin,
                 const CommonTime& tmax = CommonTime::END_OF_TIME)
-         throw()
+         noexcept
       {
             // loop over satellites
          typename SatTable::iterator it;
@@ -676,7 +676,7 @@ namespace gpstk
          // remaining functions are not virtual
 
          /// Remove all data and reset time limits
-      inline void clear() throw()
+      inline void clear() noexcept
       {
          typename std::map<SatID, DataTable>::iterator satit;
          for(satit=tables.begin(); satit!=tables.end(); ++satit)
@@ -685,14 +685,14 @@ namespace gpstk
       }
 
          /// Return true if the given SatID is present in the store
-      virtual bool isPresent(const SatID& sat) const throw()
+      virtual bool isPresent(const SatID& sat) const noexcept
       { return (tables.find(sat) != tables.end()); }
 
          /** Determine if the input TimeSystem conflicts with the
           * stored TimeSystem.
           * @param[in] ts TimeSystem to compare with stored TimeSystem
           * @throw InvalidRequest if time systems are inconsistent */
-      void checkTimeSystem(const TimeSystem& ts) const throw(InvalidRequest)
+      void checkTimeSystem(const TimeSystem& ts) const noexcept(false)
       {
          if(ts != TimeSystem::Any && storeTimeSystem != TimeSystem::Any
             && ts != storeTimeSystem)
@@ -707,7 +707,7 @@ namespace gpstk
          /** Get the earliest time of data in the data tables.
           * @return the earliest time
           * @throw InvalidRequest if the store is empty. */
-      CommonTime getInitialTime() const throw()
+      CommonTime getInitialTime() const noexcept
       {
          CommonTime initialTime(CommonTime::END_OF_TIME);
          if(tables.size() == 0) return initialTime;
@@ -731,7 +731,7 @@ namespace gpstk
 
          /** Get the latest time of data in the data tables.
           * @return the latest time */
-      CommonTime getFinalTime() const throw()
+      CommonTime getFinalTime() const noexcept
       {
          CommonTime finalTime(CommonTime::BEGINNING_OF_TIME);
          if(tables.size() == 0)
@@ -761,7 +761,7 @@ namespace gpstk
          /** Get the earliest time of data in the store for the given
           * satellite.
           * @return the first time. */
-      CommonTime getInitialTime(const SatID& sat) const throw()
+      CommonTime getInitialTime(const SatID& sat) const noexcept
       {
          CommonTime initialTime(CommonTime::END_OF_TIME);
          if(tables.size() == 0)
@@ -776,7 +776,7 @@ namespace gpstk
 
          /** Get the latest time of data in the store for the given satellite.
           * @return the last time. */
-      CommonTime getFinalTime(const SatID& sat) const throw()
+      CommonTime getFinalTime(const SatID& sat) const noexcept
       {
          CommonTime finalTime(CommonTime::BEGINNING_OF_TIME);
          if(tables.size() == 0)
@@ -795,7 +795,7 @@ namespace gpstk
           * Note that the interval includes both it1 and it2. */
       void dumpInterval(typename DataTable::const_iterator& it1,
                         typename DataTable::const_iterator& it2,
-                        std::ostream& os = std::cout) const throw()
+                        std::ostream& os = std::cout) const noexcept
       {
          const char *fmt="%4Y/%02m/%02d %2H:%02M:%02S";
          typename DataTable::const_iterator it(it1);
@@ -809,20 +809,20 @@ namespace gpstk
       }
 
          /// Does this store contain position, etc data stored in the tables?
-      bool hasPosition() const throw() { return havePosition; }
-      bool hasVelocity() const throw() { return haveVelocity; }
-      bool hasClockBias() const throw() { return haveClockBias; }
-      bool hasClockDrift() const throw() { return haveClockDrift; }
+      bool hasPosition() const noexcept { return havePosition; }
+      bool hasVelocity() const noexcept { return haveVelocity; }
+      bool hasClockBias() const noexcept { return haveClockBias; }
+      bool hasClockDrift() const noexcept { return haveClockDrift; }
 
          /// Get number of satellites available
-      inline int nsats(void) const throw() { return tables.size(); }
+      inline int nsats(void) const noexcept { return tables.size(); }
 
          /// Is the given satellite present?
-      bool hasSatellite(const SatID& sat) const throw()
+      bool hasSatellite(const SatID& sat) const noexcept
       { return isPresent(sat); }
 
          /// Get a list (std::vector) of SatIDs present in the store
-      std::vector<SatID> getSatList(void) const throw()
+      std::vector<SatID> getSatList(void) const noexcept
       {
          std::vector<SatID> satlist;
          typename SatTable::const_iterator it;
@@ -835,7 +835,7 @@ namespace gpstk
       }
 
          /// Get the total number of data records in the store
-      inline int ndata(void) const throw()
+      inline int ndata(void) const noexcept
       {
          int n(0);
          typename SatTable::const_iterator sit;
@@ -847,7 +847,7 @@ namespace gpstk
       }
 
          /// Get the number of data records for the given sat
-      inline int ndata(const SatID& sat) const throw()
+      inline int ndata(const SatID& sat) const noexcept
       {
          typename SatTable::const_iterator it(tables.find(sat));
          if(it == tables.end())
@@ -861,7 +861,7 @@ namespace gpstk
       }
 
          /// Get the number of data records for the given satellite system
-      inline int ndata(const SatID::SatelliteSystem& sys) const throw()
+      inline int ndata(const SatID::SatelliteSystem& sys) const noexcept
       {
          int n(0);
          typename SatTable::const_iterator sit;
@@ -874,13 +874,13 @@ namespace gpstk
       }
 
          /// same as ndata()
-      inline int size(void) const throw() { return ndata(); }
+      inline int size(void) const noexcept { return ndata(); }
 
          /** compute the nominal timestep of the data table for the
           * given satellite
           * @return 0 if satellite is not found, else the nominal
           *   timestep in seconds. */
-      double nomTimeStep(const SatID& sat) const throw()
+      double nomTimeStep(const SatID& sat) const noexcept
       {
             // get the table for this sat
          typename SatTable::const_iterator it(tables.find(sat));
@@ -937,39 +937,39 @@ namespace gpstk
       }
 
          /// Is gap checking on?
-      bool isDataGapCheck(void) throw() { return checkDataGap; }
+      bool isDataGapCheck(void) noexcept { return checkDataGap; }
 
          /// Disable checking of data gaps.
-      void disableDataGapCheck(void) throw() { checkDataGap = false; }
+      void disableDataGapCheck(void) noexcept { checkDataGap = false; }
 
          /// Get current gap interval.
-      double getGapInterval(void) throw() { return gapInterval; }
+      double getGapInterval(void) noexcept { return gapInterval; }
 
          /// Set gap interval and turn on gap checking
-      void setGapInterval(double interval) throw()
+      void setGapInterval(double interval) noexcept
       { checkDataGap = true; gapInterval = interval; }
 
          /// Is interval checking on?
-      bool isIntervalCheck(void) throw() { return checkInterval; }
+      bool isIntervalCheck(void) noexcept { return checkInterval; }
 
          /// Disable checking of maximum interval.
-      void disableIntervalCheck(void) throw() { checkInterval = false; }
+      void disableIntervalCheck(void) noexcept { checkInterval = false; }
 
          /// Get current maximum interval.
-      double getMaxInterval(void) throw() { return maxInterval; }
+      double getMaxInterval(void) noexcept { return maxInterval; }
 
          /// Set maximum interval and turn on interval checking
-      void setMaxInterval(double interval) throw()
+      void setMaxInterval(double interval) noexcept
       {
          checkInterval = true;
          maxInterval = interval;
       }
 
          /// get the store's time system
-      TimeSystem getTimeSystem(void) throw() { return storeTimeSystem; }
+      TimeSystem getTimeSystem(void) noexcept { return storeTimeSystem; }
 
          /// set the store's time system
-      void setTimeSystem(const TimeSystem& ts) throw()
+      void setTimeSystem(const TimeSystem& ts) noexcept
       { storeTimeSystem = ts; }
 
    };

--- a/core/lib/GNSSEph/XvtStore.hpp
+++ b/core/lib/GNSSEph/XvtStore.hpp
@@ -90,7 +90,7 @@ namespace gpstk
           * @param[in] t the time to look up
           * @return the Xvt of the object at the indicated time */
       virtual Xvt computeXvt(const IndexType& id, const CommonTime& t)
-         const throw() = 0;
+         const noexcept = 0;
 
          /** Get the satellite health at a specific time.
           * @param[in] id the object's identifier
@@ -98,7 +98,7 @@ namespace gpstk
           * @return the health status of the object at the indicated time. */
       virtual Xvt::HealthStatus getSVHealth(const IndexType& id,
                                             const CommonTime& t)
-         const throw() = 0;
+         const noexcept = 0;
 
          /// A debugging function that outputs in human readable form,
          /// all data stored in this object.

--- a/core/lib/Math/Matrix/MatrixBase.hpp
+++ b/core/lib/Math/Matrix/MatrixBase.hpp
@@ -137,7 +137,7 @@ namespace gpstk
 
          /// copies out column c into a vector starting with row r
       Vector<T> colCopy(size_t c, size_t r = 0) const
-         throw(MatrixException)
+         noexcept(false)
       { 
 #ifdef RANGECHECK
          if ((c >= cols()) || (r >= rows()))
@@ -155,7 +155,7 @@ namespace gpstk
 
          /// copies out row r into a vector starting with column c
       Vector<T> rowCopy(size_t r, size_t c = 0) const
-         throw(MatrixException)
+         noexcept(false)
       { 
 #ifdef RANGECHECK
          if ((c >= cols()) || (r >= rows()))
@@ -173,7 +173,7 @@ namespace gpstk
 
          /// copies out diagonal into a vector
       Vector<T> diagCopy(void) const
-         throw(MatrixException)
+         noexcept(false)
       { 
          size_t i, n(cols());
          if(rows() < n) n = rows();
@@ -186,7 +186,7 @@ namespace gpstk
    protected:
          /// returns the const (i,j) element from the matrix
       inline T constMatrixRef(size_t i, size_t j) const
-         throw(MatrixException)
+         noexcept(false)
       {
          const BaseClass& b = static_cast<const BaseClass&>(*this);
 #ifdef RANGECHECK
@@ -272,7 +272,7 @@ namespace gpstk
          /** performs = on each element of this matrix with each
           * element of x */
       template <class E> BaseClass& assignFrom(const ConstMatrixBase<T, E>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacro(=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -291,7 +291,7 @@ namespace gpstk
          /** performs = on each element of this matrix with each
           * element of x */
       template <class E> BaseClass& assignFrom(const ConstVectorBase<T, E>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacroVecSource(=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -310,7 +310,7 @@ namespace gpstk
          /** performs = on each element of this matrix with each
           * element of x */
       BaseClass& assignFrom(const std::valarray<T>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacroVecSource(=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -354,7 +354,7 @@ namespace gpstk
          /** performs += on each element of this matrix with each
           * element of x */
       template <class E> BaseClass& operator+=(const ConstMatrixBase<T, E>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacro(+=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -373,7 +373,7 @@ namespace gpstk
          /** performs += on each element of this matrix with each
           * element of x */
       template <class E> BaseClass& operator+=(const ConstVectorBase<T, E>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacroVecSource(+=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -392,7 +392,7 @@ namespace gpstk
          /** performs += on each element of this matrix with each
           * element of x */
       BaseClass& operator+=(const std::valarray<T>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacroVecSource(+=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -437,7 +437,7 @@ namespace gpstk
          /** performs -= on each element of this matrix with each
           * element of x */
       template <class E> BaseClass& operator-=(const ConstMatrixBase<T, E>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacro(-=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -456,7 +456,7 @@ namespace gpstk
          /** performs -= on each element of this matrix with each
           * element of x */
       template <class E> BaseClass& operator-=(const ConstVectorBase<T, E>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacroVecSource(-=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -475,7 +475,7 @@ namespace gpstk
          /** performs -= on each element of this matrix with each
           * element of x */
       BaseClass& operator-=(const std::valarray<T>& x)
-         throw(MatrixException)
+         noexcept(false)
       {
             //MatBaseArrayAssignMacroVecSource(-=);
          BaseClass& me = static_cast<BaseClass&>(*this);
@@ -554,7 +554,7 @@ namespace gpstk
 
          /// swaps rows row1 and row2 in this matrix.
       BaseClass& swapRows(size_t row1, size_t row2) 
-         throw(MatrixException)
+         noexcept(false)
       {
          BaseClass& me = static_cast<BaseClass&>(*this);
 #ifdef RANGECHECK
@@ -577,7 +577,7 @@ namespace gpstk
 
          /// swaps columns col1 and col2 in this matrix.
       BaseClass& swapCols(size_t col1, size_t col2) 
-         throw(MatrixException)
+         noexcept(false)
       {
          BaseClass& me = static_cast<BaseClass&>(*this);
 #ifdef RANGECHECK
@@ -628,7 +628,7 @@ namespace gpstk
          /// to see if it's a valid slice.
       inline void matSliceCheck(size_t sourceRowSize, 
                                 size_t sourceColSize) const
-         throw(MatrixException)
+         noexcept(false)
       {
             //#ifdef RANGECHECK
          if (rowSize() > 0)

--- a/core/lib/Math/Matrix/MatrixBaseOperators.hpp
+++ b/core/lib/Math/Matrix/MatrixBaseOperators.hpp
@@ -74,7 +74,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    BaseClass& ident(RefMatrixBase<T, BaseClass>& m)
-      throw (MatrixException)
+      noexcept(false)
    {
       BaseClass& me = static_cast<BaseClass&>(m);
       if ( (me.rows() != me.cols()) || (me.cols() < 1) )
@@ -94,7 +94,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline T trace(const ConstMatrixBase<T, BaseClass>& m)
-      throw (MatrixException)
+      noexcept(false)
    {
       if ((!m.isSquare()) || (m.rows() == 0))
       {

--- a/core/lib/Math/Matrix/MatrixFunctors.hpp
+++ b/core/lib/Math/Matrix/MatrixFunctors.hpp
@@ -102,7 +102,7 @@ namespace gpstk
          // Singular Value Decomposition
       template <class BaseClass>
       bool operator() (const ConstMatrixBase<T, BaseClass>& mat)
-         throw (MatrixException)
+         noexcept(false)
       {
          const T eps=T(8)*std::numeric_limits<T>::epsilon();
          bool flip=false;
@@ -345,7 +345,7 @@ namespace gpstk
          // 1/0 is replaced by 0. Result is returned as b.
       template <class BaseClass>
       void backSub(RefVectorBase<T, BaseClass>& b) const 
-         throw(MatrixException)
+         noexcept(false)
       {
          if(b.size() != U.rows())
          {
@@ -367,7 +367,7 @@ namespace gpstk
 
          /// sort singular values - default in descending order
       void sort(bool descending=true)
-         throw(MatrixException)
+         noexcept(false)
       {
          size_t i;
          int j;         // j must be allowed to go negative
@@ -390,7 +390,7 @@ namespace gpstk
 
          /// compute determinant from SVD
       inline T det(void)
-         throw(MatrixException)
+         noexcept(false)
       {
          T d(1);
          for(size_t i=0; i<S.size(); i++) d *= S(i);
@@ -430,7 +430,7 @@ namespace gpstk
          /// Does the decomposition.
       template <class BaseClass>
       void operator() (const ConstMatrixBase<T, BaseClass>& m)
-         throw (MatrixException)
+         noexcept(false)
       {
          if(!m.isSquare() || m.rows()<1) {
             MatrixException e("LUDecomp requires a square, non-trivial matrix");
@@ -500,7 +500,7 @@ namespace gpstk
          /// Solution overwrites input Vector v
       template <class BaseClass2>
       void backSub(RefVectorBase<T, BaseClass2>& v) const
-         throw (MatrixException)
+         noexcept(false)
       {
          if(LU.rows() != v.size()) {
             MatrixException e("Vector size does not match dimension of LUDecomp");
@@ -533,7 +533,7 @@ namespace gpstk
 
          /// compute determinant from LUD
       inline T det(void)
-         throw(MatrixException)
+         noexcept(false)
       {
          T d(static_cast<T>(parity));
          for(size_t i=0; i<LU.rows(); i++) d *= LU(i,i);
@@ -584,7 +584,7 @@ namespace gpstk
          /// @todo potential complex number problem!
       template <class BaseClass>
       void operator() (const ConstMatrixBase<T, BaseClass>& m)
-         throw (MatrixException)
+         noexcept(false)
       {
          if(!m.isSquare()) {
             MatrixException e("Cholesky requires a square matrix");
@@ -639,7 +639,7 @@ namespace gpstk
          // LT*x=y for x. x is returned as b.
       template <class BaseClass2>
       void backSub(RefVectorBase<T, BaseClass2>& b) const
-         throw (MatrixException)
+         noexcept(false)
       {
          if (L.rows() != b.size())
          {
@@ -684,7 +684,7 @@ namespace gpstk
    {
    public:
       template <class BaseClass>
-      void operator() (const ConstMatrixBase<T, BaseClass>& m) throw(MatrixException)
+      void operator() (const ConstMatrixBase<T, BaseClass>& m) noexcept(false)
       {
          if(!m.isSquare()) {
             MatrixException e("CholeskyCrout requires a square matrix");
@@ -738,7 +738,7 @@ namespace gpstk
          // orthogonal transformation which triangularizes the matrix.
       template <class BaseClass>
       inline void operator() (const ConstMatrixBase<T, BaseClass>& m)
-         throw (MatrixException)
+         noexcept(false)
       {
          A = m;
          size_t i,j,k;

--- a/core/lib/Math/Matrix/MatrixOperators.hpp
+++ b/core/lib/Math/Matrix/MatrixOperators.hpp
@@ -58,7 +58,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator&&(const ConstMatrixBase<T, BaseClass1>& l, 
                                const ConstMatrixBase<T, BaseClass2>& r) 
-      throw(MatrixException)
+      noexcept(false)
    {
       if (l.cols() != r.cols())
       {
@@ -88,7 +88,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator&&(const ConstMatrixBase<T, BaseClass1>& t, 
                                const ConstVectorBase<T, BaseClass2>& b) 
-      throw(MatrixException)
+      noexcept(false)
    {
       if (t.cols() != b.size())
       {
@@ -117,7 +117,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator&&(const ConstVectorBase<T, BaseClass1>& t, 
                                const ConstMatrixBase<T, BaseClass2>& b) 
-      throw(MatrixException)
+      noexcept(false)
    {
       if (t.size() != b.cols())
       {
@@ -146,7 +146,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator||(const ConstMatrixBase<T, BaseClass1>& l,
                                const ConstMatrixBase<T, BaseClass2>& r)  
-      throw(MatrixException)
+      noexcept(false)
    {
       if (l.rows() != r.rows())
       {
@@ -176,7 +176,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator||(const ConstMatrixBase<T, BaseClass1>& l,
                                const ConstVectorBase<T, BaseClass2>& r)
-      throw(MatrixException)
+      noexcept(false)
    {
       if (l.rows() != r.size())
       {
@@ -205,7 +205,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator||(const ConstVectorBase<T, BaseClass1>& l,
                                const ConstMatrixBase<T, BaseClass2>& r)
-      throw(MatrixException)
+      noexcept(false)
    {
       if (l.size() != r.rows())
       {
@@ -234,7 +234,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator||(const ConstVectorBase<T, BaseClass1>& l,
                                const ConstVectorBase<T, BaseClass2>& r)
-      throw(MatrixException)
+      noexcept(false)
    {
       if (l.size() != r.size())
       {
@@ -262,7 +262,7 @@ namespace gpstk
    template <class T, class BaseClass>
    inline Matrix<T> minorMatrix(const ConstMatrixBase<T, BaseClass>& l,
                                 size_t row, size_t col) 
-      throw(MatrixException)
+      noexcept(false)
    {
       if ((row >= l.rows()) || (col >= l.cols()))
       {
@@ -340,7 +340,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline T det(const ConstMatrixBase<T, BaseClass>& m) 
-      throw(MatrixException)
+      noexcept(false)
    {
       try
       {
@@ -360,7 +360,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline T condNum(const ConstMatrixBase<T, BaseClass>& m, T& bigNum, T& smallNum) 
-      throw ()
+      noexcept
    {
       SVD<T> svd;
       svd(m);
@@ -379,7 +379,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline T condNum(const ConstMatrixBase<T, BaseClass>& m) 
-      throw ()
+      noexcept
    {
       T bigNum, smallNum;
       return condNum(m, bigNum, smallNum);
@@ -390,7 +390,7 @@ namespace gpstk
        */
    template <class T>
    inline Matrix<T> ident(size_t dim)
-      throw(MatrixException)
+      noexcept(false)
    {
       if (dim == 0)
       {
@@ -409,7 +409,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> diag(const ConstMatrixBase<T, BaseClass>& m)
-      throw(MatrixException)
+      noexcept(false)
    {
       if ( (m.rows() != m.cols()) || (m.cols() < 1) )
       {
@@ -432,7 +432,7 @@ namespace gpstk
    template <class T, class BaseClass>
    inline Matrix<T> blkdiag(const ConstMatrixBase<T, BaseClass>& m1,
                             const ConstMatrixBase<T, BaseClass>& m2)
-      throw(MatrixException)
+      noexcept(false)
    {
       if ( (m1.rows() != m1.cols()) || (m1.cols() < 1) ||
            (m2.rows() != m2.cols()) || (m2.cols() < 1) )
@@ -467,7 +467,7 @@ namespace gpstk
    inline Matrix<T> blkdiag(const ConstMatrixBase<T, BaseClass>& m1,
                             const ConstMatrixBase<T, BaseClass>& m2,
                             const ConstMatrixBase<T, BaseClass>& m3)
-      throw(MatrixException)
+      noexcept(false)
    { return blkdiag( blkdiag(m1,m2), m3 ); }
 
    template <class T, class BaseClass>
@@ -475,7 +475,7 @@ namespace gpstk
                             const ConstMatrixBase<T, BaseClass>& m2,
                             const ConstMatrixBase<T, BaseClass>& m3,
                             const ConstMatrixBase<T, BaseClass>& m4)
-      throw(MatrixException)
+      noexcept(false)
    { return blkdiag( blkdiag(m1,m2,m3), m4 ); }
 
 
@@ -486,7 +486,7 @@ namespace gpstk
        */
    template <class T>
    inline Matrix<T> rotation(T angle, int axis)
-      throw(MatrixException)
+      noexcept(false)
    {
       if (axis < 1 || axis > 3)
       {
@@ -510,7 +510,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverse(const ConstMatrixBase<T, BaseClass>& m)
-      throw (MatrixException)
+      noexcept(false)
    {
       if ((m.rows() != m.cols()) || (m.cols() == 0))
       {
@@ -582,7 +582,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverseLUD(const ConstMatrixBase<T, BaseClass>& m)
-      throw (MatrixException)
+      noexcept(false)
    {
       if ((m.rows() != m.cols()) || (m.cols() == 0)) {
          MatrixException e("inverseLUD() requires non-trivial square matrix");
@@ -611,7 +611,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverseLUD(const ConstMatrixBase<T, BaseClass>& m, T& determ)
-      throw (MatrixException)
+      noexcept(false)
    {
       if ((m.rows() != m.cols()) || (m.cols() == 0)) {
          MatrixException e("inverseLUD() requires non-trivial square matrix");
@@ -643,7 +643,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverseSVD(const ConstMatrixBase<T, BaseClass>& m,
-                               const T tol=T(1.e-8)) throw (MatrixException)
+                               const T tol=T(1.e-8)) noexcept(false)
    {
       if ((m.rows() != m.cols()) || (m.cols() == 0)) {
          MatrixException e("inverseSVD() requires non-trivial square matrix");
@@ -681,7 +681,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverseSVD(const ConstMatrixBase<T, BaseClass>& m,
-                               T& bigNum, T& smallNum, const T tol=T(1.e-8)) throw (MatrixException)
+                               T& bigNum, T& smallNum, const T tol=T(1.e-8)) noexcept(false)
    {
       if ((m.rows() != m.cols()) || (m.cols() == 0)) {
          MatrixException e("inverseSVD() requires non-trivial square matrix");
@@ -725,7 +725,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverseSVD(const ConstMatrixBase<T, BaseClass>& m,
-                               Vector<T>& sv, const T tol=T(1.e-8)) throw (MatrixException)
+                               Vector<T>& sv, const T tol=T(1.e-8)) noexcept(false)
    {
       if ((m.rows() != m.cols()) || (m.cols() == 0)) {
          MatrixException e("inverseSVD() requires non-trivial square matrix");
@@ -770,7 +770,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline Matrix<T> inverseChol(const ConstMatrixBase<T, BaseClass>& m)
-      throw (MatrixException)
+      noexcept(false)
    {
       int N = m.rows(), i, j, k;
       double sum;
@@ -803,7 +803,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator* (const ConstMatrixBase<T, BaseClass1>& l, 
                                const ConstMatrixBase<T, BaseClass2>& r)
-      throw (MatrixException)
+      noexcept(false)
    {
       if (l.cols() != r.rows())
       {
@@ -827,7 +827,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Vector<T> operator* (const ConstMatrixBase<T, BaseClass1>& m, 
                                const ConstVectorBase<T, BaseClass2>& v)
-      throw (MatrixException)
+      noexcept(false)
    {
       if (v.size() != m.cols())
       {
@@ -851,7 +851,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Vector<T> operator* (const ConstVectorBase<T, BaseClass1>& v, 
                                const ConstMatrixBase<T, BaseClass2>& m)
-      throw (gpstk::MatrixException)
+      noexcept(false)
    {
       if (v.size() != m.rows())
       {
@@ -876,7 +876,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator+ (const ConstMatrixBase<T, BaseClass1>& l,
                                const ConstMatrixBase<T, BaseClass2>& r)
-      throw (MatrixException)
+      noexcept(false)
    {
       if (l.cols() != r.cols() || l.rows() != r.rows())
       {
@@ -899,7 +899,7 @@ namespace gpstk
    template <class T, class BaseClass1, class BaseClass2>
    inline Matrix<T> operator- (const ConstMatrixBase<T, BaseClass1>& l,
                                const ConstMatrixBase<T, BaseClass2>& r)
-      throw (MatrixException)
+      noexcept(false)
    {
       if (l.cols() != r.cols() || l.rows() != r.rows())
       {
@@ -922,7 +922,7 @@ namespace gpstk
    template <class T, class BaseClass>
    inline Matrix<T> outer(const ConstVectorBase<T, BaseClass>& v,
                           const ConstVectorBase<T, BaseClass>& w)
-      throw (MatrixException)
+      noexcept(false)
    {
       if(v.size()*w.size() == 0) {
          MatrixException e("Zero length vector(s)");
@@ -940,7 +940,7 @@ namespace gpstk
        */
    template <class T, class BaseClass>
    inline T maxabs(const ConstMatrixBase<T, BaseClass>& a)
-      throw ()
+      noexcept
    {
       T m=0;
       for(int i = 0; i < a.rows(); i++)

--- a/core/lib/Math/MiscMath.hpp
+++ b/core/lib/Math/MiscMath.hpp
@@ -62,7 +62,7 @@ namespace gpstk
    T SimpleLagrangeInterpolation(const std::vector<T>& X,
                                  const std::vector<T>& Y,
                                  const T x)
-      throw(Exception)
+      noexcept(false)
    {
       if(Y.size() < X.size()) {
          GPSTK_THROW(Exception("Input vectors must be of same size"));
@@ -90,7 +90,7 @@ namespace gpstk
       /// N=8 ~0.1mm level and N=10 ~numerical noise errors; best to use N>=8.
    template <class T>
    T LagrangeInterpolation(const std::vector<T>& X, const std::vector<T>& Y,
-                           const T& x, T& err) throw(Exception)
+                           const T& x, T& err) noexcept(false)
    {
       if(Y.size() < X.size() || X.size() < 4) {
          GPSTK_THROW(Exception("Input vectors must be of same length, at least 4"));
@@ -143,7 +143,7 @@ namespace gpstk
       /// available; estimates of velocity, and especially clock drift, not as accurate.
    template <class T>
    void LagrangeInterpolation(const std::vector<T>& X, const std::vector<T>& Y,
-                              const T& x, T& y, T& dydx) throw(Exception)
+                              const T& x, T& y, T& dydx) noexcept(false)
    {
       if(Y.size() < X.size() || X.size() < 4) {
          GPSTK_THROW(Exception("Input vectors must be of same length, at least 4"));

--- a/core/lib/Math/Triple.cpp
+++ b/core/lib/Math/Triple.cpp
@@ -74,7 +74,7 @@ namespace gpstk
    }
 
    Triple& Triple :: operator=(const valarray<double>& right)
-      throw(GeometryException)
+      noexcept(false)
    {
       if (right.size() != 3)
       {
@@ -104,7 +104,7 @@ namespace gpstk
 
       // returns the dot product of the two vectors
    double Triple :: dot(const Triple& right) const
-      throw()
+      noexcept
    {
       Triple z;
       z = (this->theArray)*(right.theArray);
@@ -115,7 +115,7 @@ namespace gpstk
 
       // retuns v1 x v2 , vector cross product
    Triple Triple :: cross(const Triple& right) const
-      throw()
+      noexcept
    {
       Triple cp;
       cp[0] = (*this)[1] * right[2] - (*this)[2] * right[1];
@@ -125,13 +125,13 @@ namespace gpstk
    }
 
 
-   double Triple :: mag() const throw()
+   double Triple :: mag() const noexcept
    {
       return std::sqrt(dot(*this));
    }
 
    Triple Triple::unitVector() const
-       throw(GeometryException)
+       noexcept(false)
    {
       double mag = std::sqrt(dot(*this));
       
@@ -147,7 +147,7 @@ namespace gpstk
 
       // function that returns the cosine of angle between this and right
    double Triple :: cosVector(const Triple& right) const
-      throw(GeometryException)
+      noexcept(false)
    {
       double rx, ry, cosvects;
    
@@ -172,7 +172,7 @@ namespace gpstk
 
       // Computes the slant range between two vectors
    double Triple :: slantRange(const Triple& right) const
-      throw()
+      noexcept
    {
       Triple z;
       z = right.theArray - this->theArray;
@@ -184,7 +184,7 @@ namespace gpstk
       // Finds the elevation angle of the second point with respect to
       // the first point
    double Triple :: elvAngle(const Triple& right) const
-      throw(GeometryException)
+      noexcept(false)
    {
       Triple z;
       z = right.theArray - this->theArray;
@@ -195,7 +195,7 @@ namespace gpstk
 
       //  Calculates a satellites azimuth from a station
    double Triple :: azAngle(const Triple& right) const
-      throw(GeometryException)
+      noexcept(false)
    {
       double xy, xyz, cosl, sinl, sint, xn1, xn2, xn3, xe1, xe2;
       double z1, z2, z3, p1, p2, test, alpha;
@@ -250,7 +250,7 @@ namespace gpstk
        * @return A triple which is the original triple rotated angle about X
        */
    Triple Triple::R1(const double& angle) const
-      throw()
+      noexcept
    {
       double ang(angle*DEG_TO_RAD);
       double sinangle(std::sin(ang));
@@ -268,7 +268,7 @@ namespace gpstk
        * @return A triple which is the original triple rotated angle about Y
        */
    Triple Triple::R2(const double& angle) const
-      throw()
+      noexcept
    {
       double ang(angle*DEG_TO_RAD);
       double sinangle(std::sin(ang));
@@ -286,7 +286,7 @@ namespace gpstk
        * @return A triple which is the original triple rotated angle about Z
        */
    Triple Triple::R3(const double& angle) const
-      throw()
+      noexcept
    {
       double ang(angle*DEG_TO_RAD);
       double sinangle(std::sin(ang));

--- a/core/lib/Math/Triple.hpp
+++ b/core/lib/Math/Triple.hpp
@@ -87,7 +87,7 @@ namespace gpstk
           * @throw GeometryException if right.size() != 3.
           */
       Triple& operator=(const std::valarray<double>& right)
-         throw(GeometryException);
+         noexcept(false);
 
          
          /// Return the data as a Vector<double> object
@@ -103,7 +103,7 @@ namespace gpstk
           * @return The dot product of \c this and \c right
           */
       double dot(const Triple& right) const 
-         throw();
+         noexcept;
    
          /**
           * Computes the Cross Product of two vectors
@@ -111,19 +111,19 @@ namespace gpstk
           * @return The cross product of \c v1 and \c v2
           */
       Triple cross(const Triple& right) const
-         throw();
+         noexcept;
    
          /**
           * Computes the Magnigude of this vector
           */
       double mag() const 
-         throw();
+         noexcept;
    
          /**
           * Returns the unit vector of this vector
           */
       Triple unitVector() const
-      	 throw(GeometryException);
+      	 noexcept(false);
       
          /**
           * Computes the Cosine of the Angle Between this vector and another.
@@ -131,7 +131,7 @@ namespace gpstk
           * @return The cosine of the angle between \c this and \c right
           */
       double cosVector(const Triple& right) const 
-         throw(GeometryException);
+         noexcept(false);
       
          /**
           * Computes the slant range between this vector and another
@@ -139,7 +139,7 @@ namespace gpstk
           * @return The slant range between \c this and \c right
           */
       double slantRange(const Triple& right) const 
-         throw();
+         noexcept;
       
          /**
           * Computes the elevation of a point with respect to this
@@ -148,7 +148,7 @@ namespace gpstk
           * @return The elevation of \c right relative to \c this
           */
       double elvAngle(const Triple& right) const 
-         throw(GeometryException);
+         noexcept(false);
       
          /**
           * Computes an azimuth from this point.
@@ -156,14 +156,14 @@ namespace gpstk
           * @return The azimuth of \c right relative to \c this
           */ 
       double azAngle(const Triple& right) const 
-         throw(GeometryException);
+         noexcept(false);
       
          /** Computes rotation about axis X.
           * @param angle    Angle to rotate, in degrees
           * @return A triple which is the original triple rotated angle about X
           */
       Triple R1(const double& angle) const
-         throw();
+         noexcept;
    
       
          /** Computes rotation about axis Y.
@@ -171,7 +171,7 @@ namespace gpstk
           * @return A triple which is the original triple rotated angle about Y
           */
       Triple R2(const double& angle) const
-         throw();
+         noexcept;
    
       
          /** Computes rotation about axis Z.
@@ -179,7 +179,7 @@ namespace gpstk
           * @return A triple which is the original triple rotated angle about Z
           */
       Triple R3(const double& angle) const
-         throw();
+         noexcept;
    
          /**
           * Return a reference to the element at /a index.

--- a/core/lib/Math/Vector/VectorBase.hpp
+++ b/core/lib/Math/Vector/VectorBase.hpp
@@ -118,7 +118,7 @@ namespace gpstk
          /** returns the element at index i by calling the base
           * class's operator[] */
       inline T constVectorRef(size_t i) const
-         throw(VectorException)
+         noexcept(false)
       {
          const BaseClass& b = static_cast<const BaseClass&>(*this);
 #ifdef RANGECHECK
@@ -245,7 +245,7 @@ namespace gpstk
    protected:
          /// Returns a modifiable object at index i.
       inline T& vecRef(size_t i) 
-         throw(VectorException)
+         noexcept(false)
       {
          BaseClass& b = static_cast<BaseClass&>(*this);
 #ifdef RANGECHECK
@@ -284,7 +284,7 @@ namespace gpstk
          /** Given the size of the source vector, checks that the
           * slice is valid. */
       inline void vecSliceCheck(size_t sourceSize) const
-         throw(VectorException)
+         noexcept(false)
       {
 #ifdef RANGECHECK
             // sanity checks...

--- a/core/lib/Math/Vector/VectorBaseOperators.hpp
+++ b/core/lib/Math/Vector/VectorBaseOperators.hpp
@@ -90,7 +90,7 @@ namespace gpstk
       /** Return the element with smallest absolute value in the vector */
    template <class T, class BaseClass>
    inline T minabs(const ConstVectorBase<T, BaseClass>& l)
-      throw (VectorException)
+      noexcept(false)
    { 
       if (l.size() == 0)
       {
@@ -107,7 +107,7 @@ namespace gpstk
 
       /** Returns the smallest element of the vector */
    template <class T, class BaseClass>
-   inline T min(const ConstVectorBase<T, BaseClass>& l) throw (VectorException)
+   inline T min(const ConstVectorBase<T, BaseClass>& l) noexcept(false)
    { 
       if (l.size() == 0)
       {

--- a/core/lib/Math/Vector/VectorOperators.hpp
+++ b/core/lib/Math/Vector/VectorOperators.hpp
@@ -161,7 +161,7 @@ namespace gpstk
    /** finds the cross product between l and r */
    template <class T, class BaseClass, class BaseClass2> 
    Vector<T> cross(const ConstVectorBase<T, BaseClass>& l, 
-                   const ConstVectorBase<T, BaseClass2>& r) throw(VectorException)
+                   const ConstVectorBase<T, BaseClass2>& r) noexcept(false)
    { 
       if ((l.size() != 3) && (r.size() != 3))
       {

--- a/core/lib/NavFilter/CNav2SanityFilter.hpp
+++ b/core/lib/NavFilter/CNav2SanityFilter.hpp
@@ -70,11 +70,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "CNav2Sanity"; }
    };
 

--- a/core/lib/NavFilter/CNavCookFilter.hpp
+++ b/core/lib/NavFilter/CNavCookFilter.hpp
@@ -70,14 +70,14 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Turn an CNAV subframe data upright.
       static void cookSubframe(CNavFilterData* fd);
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Cook"; }
    };
 

--- a/core/lib/NavFilter/CNavCrossSourceFilter.hpp
+++ b/core/lib/NavFilter/CNavCrossSourceFilter.hpp
@@ -76,11 +76,11 @@ namespace gpstk
       virtual void finalize(NavMsgList& msgBitsOut);
 
          /// Internally stores 1 epoch's worth of subframe data.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 1; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "CrossSource"; }
 
       virtual void setMinIdentical(const unsigned value)

--- a/core/lib/NavFilter/CNavEmptyFilter.hpp
+++ b/core/lib/NavFilter/CNavEmptyFilter.hpp
@@ -68,11 +68,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Empty"; }
    };
 

--- a/core/lib/NavFilter/CNavParityFilter.hpp
+++ b/core/lib/NavFilter/CNavParityFilter.hpp
@@ -66,11 +66,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "CRC"; }
    };
 

--- a/core/lib/NavFilter/CNavTOWFilter.hpp
+++ b/core/lib/NavFilter/CNavTOWFilter.hpp
@@ -70,11 +70,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "TOW"; }
    };
 

--- a/core/lib/NavFilter/LNavAlmValFilter.hpp
+++ b/core/lib/NavFilter/LNavAlmValFilter.hpp
@@ -68,11 +68,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "AlmVal"; }
 
          /// Specific value range checks

--- a/core/lib/NavFilter/LNavCookFilter.hpp
+++ b/core/lib/NavFilter/LNavCookFilter.hpp
@@ -70,14 +70,14 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Turn an LNAV subframe data upright.
       static void cookSubframe(LNavFilterData* fd);
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Cook"; }
    };
 

--- a/core/lib/NavFilter/LNavCrossSourceFilter.hpp
+++ b/core/lib/NavFilter/LNavCrossSourceFilter.hpp
@@ -77,11 +77,11 @@ namespace gpstk
       virtual void finalize(NavMsgList& msgBitsOut);
 
          /// Internally stores 1 epoch's worth of subframe data.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 1; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "CrossSource"; }
 
    protected:

--- a/core/lib/NavFilter/LNavEmptyFilter.hpp
+++ b/core/lib/NavFilter/LNavEmptyFilter.hpp
@@ -67,11 +67,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Empty"; }
    };
 

--- a/core/lib/NavFilter/LNavEphMaker.hpp
+++ b/core/lib/NavFilter/LNavEphMaker.hpp
@@ -106,11 +106,11 @@ namespace gpstk
       virtual void finalize(NavMsgList& msgBitsOut);
 
          /// Internally stores 3 epochs worth of subframe data.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 3; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "EphMaker"; }
 
          /// Storage for the assembly of ephemerides.

--- a/core/lib/NavFilter/LNavOrderFilter.hpp
+++ b/core/lib/NavFilter/LNavOrderFilter.hpp
@@ -110,11 +110,11 @@ namespace gpstk
       virtual void finalize(NavMsgList& msgBitsOut);
 
          /// Internal storage includes a user-specified number of epochs.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return procDepth; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Order"; }
 
       unsigned procDepth;

--- a/core/lib/NavFilter/LNavParityFilter.hpp
+++ b/core/lib/NavFilter/LNavParityFilter.hpp
@@ -66,11 +66,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Parity"; }
    };
 

--- a/core/lib/NavFilter/LNavTLMHOWFilter.hpp
+++ b/core/lib/NavFilter/LNavTLMHOWFilter.hpp
@@ -71,11 +71,11 @@ namespace gpstk
       {}
 
          /// No internal storage of subframe data so return 0.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return 0; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "TLMHOW"; }
    };
 

--- a/core/lib/NavFilter/NavFilter.hpp
+++ b/core/lib/NavFilter/NavFilter.hpp
@@ -92,7 +92,7 @@ namespace gpstk
           * subframe of time t+1 or later, and so on.
           * Most filters will return a value of 0, indicating an
           * immediate validation of the data. */
-      virtual unsigned processingDepth() const throw() = 0;
+      virtual unsigned processingDepth() const noexcept = 0;
 
          /** Return a simple string containing the name of the filter
           * for the purposes of providing some user feedback as to
@@ -101,7 +101,7 @@ namespace gpstk
           * using this method instead of type_id.name() is that the
           * latter often returns compiler-munged names rather than
           * human-readable ones. */
-      virtual std::string filterName() const throw() = 0;
+      virtual std::string filterName() const noexcept = 0;
 
          /// Debug support 
       virtual void dumpRejected(std::ostream& out) const; 

--- a/core/lib/NavFilter/NavFilterMgr.cpp
+++ b/core/lib/NavFilter/NavFilterMgr.cpp
@@ -119,7 +119,7 @@ namespace gpstk
 
    unsigned NavFilterMgr ::
    processingDepth()
-      const throw()
+      const noexcept
    {
       FilterList::const_iterator fli;
       unsigned rv = 1;

--- a/core/lib/NavFilter/NavFilterMgr.hpp
+++ b/core/lib/NavFilter/NavFilterMgr.hpp
@@ -220,7 +220,7 @@ namespace gpstk
           * SubframeBuf buf(numRx * numCode * numChl * mgr.processingDepth());
           * \endcode
           */
-      unsigned processingDepth() const throw();
+      unsigned processingDepth() const noexcept;
 
          /** This set contains any filters with rejected data after a
           * validate() or finalize() call.  The set will be cleared at

--- a/core/lib/NavFilter/NavOrderFilter.hpp
+++ b/core/lib/NavFilter/NavOrderFilter.hpp
@@ -110,11 +110,11 @@ namespace gpstk
       virtual void finalize(NavMsgList& msgBitsOut);
 
          /// Internal storage includes a user-specified number of epochs.
-      virtual unsigned processingDepth() const throw()
+      virtual unsigned processingDepth() const noexcept
       { return procDepth; }
 
          /// Return the filter name.
-      virtual std::string filterName() const throw()
+      virtual std::string filterName() const noexcept
       { return "Order"; }
 
       unsigned procDepth;

--- a/core/lib/PosSol/Combinations.hpp
+++ b/core/lib/PosSol/Combinations.hpp
@@ -55,7 +55,7 @@ namespace gpstk {
 class Combinations {
 public:
    /// Default constructor
-   Combinations(void) throw()
+   Combinations(void) noexcept
    {
       nc = n = k = 0;
       Index = std::vector<int>(0);
@@ -63,18 +63,18 @@ public:
 
    /// Constructor for C(n,k) = combinations of n things taken k at a time (k <= n)
    /// @throw on invalid input (k>n).
-   Combinations(int N, int K) throw(Exception)
+   Combinations(int N, int K) noexcept(false)
    { init(N,K); }
 
    /// copy constructor
    Combinations(const Combinations& right)
-      throw()
+      noexcept
    {
       *this = right;
    }
 
    /// Assignment operator.
-   Combinations& operator=(const Combinations& right) throw()
+   Combinations& operator=(const Combinations& right) noexcept
    {
       init(right.n,right.k);
       nc = right.nc;
@@ -84,7 +84,7 @@ public:
 
    /// Compute the next combination, returning the number of combinations computed
    /// so far; if there are no more combinations, return -1.
-   int Next(void) throw() {
+   int Next(void) noexcept {
       if(k < 1) return -1;
       if(Increment(k-1) != -1) return ++nc;
       return -1;
@@ -92,7 +92,7 @@ public:
 
    /// Return index i (0 <= i < n) of jth selection (0 <= j < k);
    /// if j is out of range, return -1.
-   int Selection(int j) throw()
+   int Selection(int j) noexcept
    {
       if(j < 0 || j >= k) return -1;
       return Index[j];
@@ -100,7 +100,7 @@ public:
 
       /// Return true if the given index j (0 <= j < n) is
       /// currently selected (i.e. if j = Selection(i) for some i)
-   bool isSelected(int j) throw()
+   bool isSelected(int j) noexcept
    {
       for(int i=0; i<k; i++)
          if(Index[i] == j) return true;
@@ -111,7 +111,7 @@ private:
 
    /// The initialization routine used by constructors.
    /// @throw on invalid input (k>n or either n or k < 0).
-   void init(int N, int K) throw(Exception)
+   void init(int N, int K) noexcept(false)
    {
       if(K > N || N < 0 || K < 0) {
          Exception e("Combinations(n,k) must have k <= n, with n,k >= 0");
@@ -127,7 +127,7 @@ private:
    }
 
    /// Recursive function to increment Index[j].
-   int Increment(int j) throw()
+   int Increment(int j) noexcept
    {
       if(Index[j] < n-k+j) {        // can this index be incremented?
          Index[j]++;

--- a/core/lib/PosSol/PRSolution.cpp
+++ b/core/lib/PosSol/PRSolution.cpp
@@ -67,7 +67,7 @@ namespace gpstk
                                      const vector<double>& Pseudorange,
                                      const XvtStore<SatID> *pEph,
                                      Matrix<double>& SVP) const
-      throw()
+      noexcept
    {
       LOG(DEBUG) << "PreparePRSolution at time " << printTime(Tr,timfmt);
 
@@ -187,7 +187,7 @@ namespace gpstk
                                     const vector<SatID::SatelliteSystem>& Syss,
                                     Vector<double>& Resids,
                                     Vector<double>& Slopes)
-      throw(Exception)
+      noexcept(false)
    {
       if(!pTropModel) {
          Exception e("Undefined tropospheric model");
@@ -502,7 +502,7 @@ namespace gpstk
                                      const vector<double>& Pseudorange,
                                      const XvtStore<SatID> *pEph,
                                      TropModel *pTropModel)
-      throw(Exception)
+      noexcept(false)
    {
       try {
          // Declare the non-swig'ed variables needed by RAIMCompute;
@@ -532,7 +532,7 @@ namespace gpstk
                                const Matrix<double>& invMC,
                                const XvtStore<SatID> *pEph,
                                TropModel *pTropModel)
-      throw(Exception)
+      noexcept(false)
    {
       try {
          //LOGlevel = ConfigureLOG::Level("DEBUG"); // uncomment to turn on DEBUG output to stdout
@@ -822,7 +822,7 @@ namespace gpstk
 
 
    // -------------------------------------------------------------------------
-   int PRSolution::DOPCompute(void) throw(Exception)
+   int PRSolution::DOPCompute(void) noexcept(false)
    {
       try {
          Matrix<double> PTP(transpose(Partials)*Partials);
@@ -839,7 +839,7 @@ namespace gpstk
 
    // -------------------------------------------------------------------------
    // conveniences for printing the solutions
-   string PRSolution::outputValidString(int iret) throw()
+   string PRSolution::outputValidString(int iret) noexcept
    {
       ostringstream oss;
       if(iret != -99) {
@@ -856,7 +856,7 @@ namespace gpstk
    }  // end PRSolution::outputValidString
 
    string PRSolution::outputNAVString(string tag, int iret, const Vector<double>& Vec)
-      throw()
+      noexcept
    {
       ostringstream oss;
 
@@ -890,7 +890,7 @@ namespace gpstk
    }  // end PRSolution::outputNAVString
 
    string PRSolution::outputPOSString(string tag, int iret, const Vector<double>& Vec)
-      throw()
+      noexcept
    {
       ostringstream oss;
 
@@ -919,7 +919,7 @@ namespace gpstk
       return oss.str();
    }  // end PRSolution::outputPOSString
 
-   string PRSolution::outputCLKString(string tag, int iret) throw()
+   string PRSolution::outputCLKString(string tag, int iret) noexcept
    {
       ostringstream oss;
 
@@ -947,7 +947,7 @@ namespace gpstk
    }  // end PRSolution::outputCLKString
 
    // NB must call DOPCompute() if SimplePRSol() only was called.
-   string PRSolution::outputRMSString(string tag, int iret) throw()
+   string PRSolution::outputRMSString(string tag, int iret) noexcept
    {
       ostringstream oss;
 
@@ -1012,7 +1012,7 @@ namespace gpstk
    }  // end PRSolution::outputRMSString
 
    string PRSolution::outputString(string tag, int iret, const Vector<double>& Vec)
-      throw()
+      noexcept
    {
       ostringstream oss;
       oss << outputNAVString(tag,iret,Vec) << endl;
@@ -1021,7 +1021,7 @@ namespace gpstk
       return oss.str();
    }  // end PRSolution::outputString
 
-   string PRSolution::errorCodeString(int iret) throw()
+   string PRSolution::errorCodeString(int iret) noexcept
    {
       string str("unknown");
       if(iret == 1) str = string("ok but perhaps degraded");
@@ -1033,7 +1033,7 @@ namespace gpstk
       return str;
    }
 
-   string PRSolution::configString(string tag) throw()
+   string PRSolution::configString(string tag) noexcept
    {
       ostringstream oss;
       oss << tag << " " << printTime(currTime,timfmt)

--- a/core/lib/PosSol/PRSolution.hpp
+++ b/core/lib/PosSol/PRSolution.hpp
@@ -77,10 +77,10 @@ namespace gpstk
          lab[0]="ECEF_X";  lab[1]="ECEF_Y"; lab[2]="ECEF_Z";
       }
 
-      void setMessage(std::string m) throw() { msg = m; }
-      std::string getMessage(void) const throw() { return msg; }
+      void setMessage(std::string m) noexcept { msg = m; }
+      std::string getMessage(void) const noexcept { return msg; }
 
-      void setLabels(std::string lab1, std::string lab2, std::string lab3) throw()
+      void setLabels(std::string lab1, std::string lab2, std::string lab3) noexcept
          { lab[0]=lab1; lab[1]=lab2; lab[2]=lab3; }
 
       Vector<double> getSol(void) const
@@ -94,7 +94,7 @@ namespace gpstk
 
       int getN(void) const { return N; }
 
-      void reset(void) throw()
+      void reset(void) noexcept
       {
          N = 0;
          sumInfo = Matrix<double>();
@@ -107,7 +107,7 @@ namespace gpstk
 
       // add to statistics, and to weighted average solution and covariance
       void add(const Vector<double>& Sol, const Matrix<double>& Cov)
-         throw(Exception)
+         noexcept(false)
       {
          try {
             // add to the statistics
@@ -138,7 +138,7 @@ namespace gpstk
       }
 
       // dump statistics and weighted average
-      void dump(std::ostream& os, std::string msg="") const throw(Exception)
+      void dump(std::ostream& os, std::string msg="") const noexcept(false)
       {
          try {
             os << "Simple statistics on " << msg << std::endl
@@ -202,13 +202,13 @@ namespace gpstk
       Vector<double> APSolution;
 
       /// constructor
-      PRSMemory() throw() { reset(); }
+      PRSMemory() noexcept { reset(); }
 
       /// destructor
-      ~PRSMemory() throw() { }
+      ~PRSMemory() noexcept { }
 
       /// reset counters, etc.; call at construction and any time for 'start over'
-      void reset(void) throw()
+      void reset(void) noexcept
       {
          fixedAPriori = false;
          nsol = ndata = 0;
@@ -227,7 +227,7 @@ namespace gpstk
       }
 
       /// Fix the apriori solution to the given constant value (XYZ,m)
-      void fixAPSolution(const double& X, const double& Y, const double& Z) throw()
+      void fixAPSolution(const double& X, const double& Y, const double& Z) noexcept
       {
          fixedAPrioriPos[0] = X;
          fixedAPrioriPos[1] = Y;
@@ -274,7 +274,7 @@ namespace gpstk
 
       /// update apriori solution with a known solution; this is done at the end of
       /// both SimplePRSolution() and RAIMCompute()
-      void updateAPSolution(const Vector<double>& Sol) throw()
+      void updateAPSolution(const Vector<double>& Sol) noexcept
       {
          APSolution = Sol;
          if(fixedAPriori)
@@ -286,7 +286,7 @@ namespace gpstk
       void add(const Vector<double>& Sol, const Matrix<double>& Cov,
                const Vector<double>& PreFitResid, const Matrix<double>& Partials,
                const Matrix<double>& invMeasCov)
-         throw(Exception)
+         noexcept(false)
       {
          was.add(Sol, Cov);
 
@@ -315,7 +315,7 @@ namespace gpstk
       }
 
       // dump statistics and weighted average
-      void dump(std::ostream& os, std::string msg="PRS") throw(Exception)
+      void dump(std::ostream& os, std::string msg="PRS") noexcept(false)
       {
          try {
             was.setMessage(msg);
@@ -381,7 +381,7 @@ namespace gpstk
    {
    public:
          /// Constructor
-       PRSolution() throw() : RMSLimit(6.5),
+       PRSolution() noexcept : RMSLimit(6.5),
                              SlopeLimit(1000.),
                              NSatsReject(-1),
                              MaxNIterations(10),
@@ -390,7 +390,7 @@ namespace gpstk
                              Valid(false)
          {}
       /// Return the status of solution
-      bool isValid() const throw() { return Valid; }
+      bool isValid() const noexcept { return Valid; }
 
       // input parameters: -------------------------------------------------
 
@@ -535,7 +535,7 @@ namespace gpstk
                             std::vector<SatID::SatelliteSystem>& Syss,
                             const std::vector<double>& Pseudorange,
                             const XvtStore<SatID> *pEph,
-                            Matrix<double>& SVP) const throw();
+                            Matrix<double>& SVP) const noexcept;
 
       /// Compute a single autonomous pseudorange solution.
       /// On output, all the member data is filled with results.
@@ -581,7 +581,7 @@ namespace gpstk
                            const double& convLimit,
                            const std::vector<SatID::SatelliteSystem>& Syss,
                            Vector<double>& Resids,
-                           Vector<double>& Slopes) throw(Exception);
+                           Vector<double>& Slopes) noexcept(false);
 
       /// Simple interface for RAIMCompute.
       /// To be deprecated once the additional two variables are exposed in swig.
@@ -590,7 +590,7 @@ namespace gpstk
                       const std::vector<double>& Pseudorange,
                       const XvtStore<SatID> *pEph,
                       TropModel *pTropModel)
-         throw(Exception);
+         noexcept(false);
 
       /// Compute a position/time solution, given satellite PRNs and pseudoranges
       /// using a RAIM algorithm. This is the main computation done by this class.
@@ -625,46 +625,46 @@ namespace gpstk
                       const Matrix<double>& invMC,
                       const XvtStore<SatID> *pEph,
                       TropModel *pTropModel)
-         throw(Exception);
+         noexcept(false);
 
       /// Compute DOPs using the partials matrix from the last successful solution.
       /// RAIMCompute(), if successful, calls this before returning.
       /// Results stored in PRSolution::TDOP,PDOP,GDOP.
-      int DOPCompute(void) throw(Exception);
+      int DOPCompute(void) noexcept(false);
 
       /// conveniences for printing the results of the pseudorange solution algorithm
       /// return string of position, error code and V/NV
       std::string outputPOSString(std::string tag, int iret=-99,
-                                    const Vector<double>& Vec=PRSNullVector) throw();
+                                    const Vector<double>& Vec=PRSNullVector) noexcept;
 
       /// return string of {SYS clock} for all systems, error code and V/NV
-      std::string outputCLKString(std::string tag, int iret=-99) throw();
+      std::string outputCLKString(std::string tag, int iret=-99) noexcept;
 
       /// return string of info in POS and CLK
       std::string outputNAVString(std::string tag, int iret=-99,
-                                    const Vector<double>& Vec=PRSNullVector) throw();
+                                    const Vector<double>& Vec=PRSNullVector) noexcept;
 
       /// return string of Nsvs, RMS residual, TDOP, PDOP, GDOP, Slope, niter, conv,
       /// satellites, error code and V/NV
-      std::string outputRMSString(std::string tag, int iret=-99) throw();
-      std::string outputValidString(int iret=-99) throw();
+      std::string outputRMSString(std::string tag, int iret=-99) noexcept;
+      std::string outputValidString(int iret=-99) noexcept;
 
       /// return string of NAV and RMS strings
       std::string outputString(std::string tag, int iret=-99,
-                               const Vector<double>& Vec=PRSNullVector) throw();
+                               const Vector<double>& Vec=PRSNullVector) noexcept;
       /// return string of the form "#tag label etc" which is header for data strings
-      std::string outputStringHeader(std::string tag) throw()
+      std::string outputStringHeader(std::string tag) noexcept
          { return outputString(tag,-999); }
 
       /// A convenience for printing the error code (return value)
-      std::string errorCodeString(int iret) throw();
+      std::string errorCodeString(int iret) noexcept;
 
       /// A convenience for printing the current configuarion
-      std::string configString(std::string tag) throw();
+      std::string configString(std::string tag) noexcept;
 
       /// Set current time
 
-      void setTime(const CommonTime& ct) throw()
+      void setTime(const CommonTime& ct) noexcept
          { currTime = ct; }
 
    private:

--- a/core/lib/RefTime/HelmertTransform.cpp
+++ b/core/lib/RefTime/HelmertTransform.cpp
@@ -55,7 +55,7 @@ namespace gpstk {
                     const double& Rx, const double& Ry, const double& Rz,
                     const double& Tx, const double& Ty, const double& Tz,
                     const double& Sc, const string& Desc, CommonTime epoch)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       // copy input
       // NB input is in degrees, members in radians
@@ -102,7 +102,7 @@ namespace gpstk {
 
    // Dump the object to a multi-line string including reference frames, the
    // 7 parameters and description.
-   string HelmertTransform::asString() const throw()
+   string HelmertTransform::asString() const noexcept
    {
       ostringstream oss;
       oss << "Helmert Transformation"
@@ -137,7 +137,7 @@ namespace gpstk {
    // @param Position& result position after transformation.
    // @throw if transformation, or inverse, cannot act on ReferenceFrame of input.
    void HelmertTransform::transform(const Position& pos, Position& result)
-      throw(InvalidRequest)
+      noexcept(false)
    {
       if(pos.getReferenceFrame() == fromFrame) {           // transform
          result = pos;

--- a/core/lib/RefTime/HelmertTransform.hpp
+++ b/core/lib/RefTime/HelmertTransform.hpp
@@ -60,7 +60,7 @@ namespace gpstk
    public:
 
       /// Default constructor
-      HelmertTransform() throw() : fromFrame(ReferenceFrame::Unknown),
+      HelmertTransform() noexcept : fromFrame(ReferenceFrame::Unknown),
                                    toFrame(ReferenceFrame::Unknown),
                                    description("Undefined")
          {};
@@ -85,17 +85,17 @@ namespace gpstk
                        const double& Tx, const double& Ty, const double& Tz,
                        const double& Scale, const std::string& Desc,
                        CommonTime epoch)
-         throw(InvalidRequest);
+         noexcept(false);
 
       /// Dump the object to a multi-line string including reference frames, the
       /// 7 parameters and description.
-      std::string asString() const throw();
+      std::string asString() const noexcept;
 
       /// Transform Position to another frame using this transform or its inverse.
       /// @param Position& pos position to be transformed; unchanged on output.
       /// @param Position& result position after transformation.
       /// @throw if transformation, or inverse, cannot act on ReferenceFrame of input.
-      void transform(const Position& pos, Position& result) throw(InvalidRequest);
+      void transform(const Position& pos, Position& result) noexcept(false);
 
       /// Transform a 3-vector, in the given frame, using this Helmert transformation.
       /// @param Vector<double>& vec 3-vector of position coordinates in "from" frame.
@@ -104,7 +104,7 @@ namespace gpstk
       /// @throw if transformation, or inverse, cannot act on ReferenceFrame of input.
       void transform(const Vector<double>& vec, const ReferenceFrame& frame,
                      Vector<double>& result)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          if(vec.size() > 3) {
             InvalidRequest e("Input Vector is not of length 3");
@@ -128,7 +128,7 @@ namespace gpstk
       /// @param Triple& result with position in new frame
       /// @throw if transformation, or inverse, cannot act on ReferenceFrame of input.
       void transform(const Triple& vec, const ReferenceFrame& frame, Triple& result)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try {
             Position pos(vec, Position::Cartesian), res;
@@ -146,7 +146,7 @@ namespace gpstk
       /// @param Xvt& result with position in new frame
       /// @throw if transformation, or inverse, cannot act on ReferenceFrame of input.
       void transform(const Xvt& xvt, Xvt& result)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try {
             Position pos(xvt.x, Position::Cartesian), res;
@@ -168,7 +168,7 @@ namespace gpstk
       void transform(const double& x, const double& y, const double& z,
                      const ReferenceFrame& frame,
                      double& rx, double& ry, double& rz)
-         throw(InvalidRequest)
+         noexcept(false)
       {
          try {
             Position pos(x,y,z,Position::Cartesian), res;
@@ -182,13 +182,13 @@ namespace gpstk
       }
 
       // accessors
-      ReferenceFrame getFromFrame(void) const throw()
+      ReferenceFrame getFromFrame(void) const noexcept
       { return fromFrame; }
 
-      ReferenceFrame getToFrame(void) const throw()
+      ReferenceFrame getToFrame(void) const noexcept
       { return toFrame; }
 
-      CommonTime getEpoch(void) const throw()
+      CommonTime getEpoch(void) const noexcept
       { return Epoch; }
 
       /// Epoch at which GLONASS transitions from PZ90 to PZ90.02

--- a/core/lib/RefTime/ReferenceFrame.cpp
+++ b/core/lib/RefTime/ReferenceFrame.cpp
@@ -56,7 +56,7 @@ namespace gpstk
        string("CGCS2000")
      };
 
-   ReferenceFrame::ReferenceFrame(const string str) throw()
+   ReferenceFrame::ReferenceFrame(const string str) noexcept
    {
       frame = Unknown;
       for(int i=0; i<count; i++) {
@@ -68,7 +68,7 @@ namespace gpstk
    }
 
    void ReferenceFrame::setReferenceFrame(const Frames& frm)
-      throw()
+      noexcept
    {
       if(frm < 0 || frm >= count)
          frame = Unknown;

--- a/core/lib/RefTime/ReferenceFrame.hpp
+++ b/core/lib/RefTime/ReferenceFrame.hpp
@@ -68,7 +68,7 @@ namespace gpstk {
       };
 
       /// Constructor, including empty constructor
-      ReferenceFrame(Frames f=Unknown) throw()
+      ReferenceFrame(Frames f=Unknown) noexcept
       {
          if(f < 0 || f >= count)
             frame = Unknown;
@@ -77,11 +77,11 @@ namespace gpstk {
       }
 
       /// Constructor from string
-      ReferenceFrame(const std::string str) throw();
+      ReferenceFrame(const std::string str) noexcept;
 
       // TD is this required?
       ///// Constructor from int
-      //ReferenceFrame(int i) throw()
+      //ReferenceFrame(int i) noexcept
       //{
       //   if(i < 0 || i >= count)
       //      frame = Unknown;
@@ -92,46 +92,46 @@ namespace gpstk {
       // copy constructor and operator= defined by the compiler
 
       /// Define using input value of Frames enum.
-      void setReferenceFrame(const Frames& f) throw();
+      void setReferenceFrame(const Frames& f) noexcept;
 
       /// Return the value of Frames enum for this object.
-      Frames getReferenceFrame() const throw()
+      Frames getReferenceFrame() const noexcept
       { return frame; }
 
       /// Return std::string for each system (these strings are const and static).
       /// @return std::string description of the frame.
-      std::string asString() const throw()
+      std::string asString() const noexcept
       { return Strings[frame]; }
 
       /// define system based on input string
       /// @param str input std::string, expected to match output string for a given
       /// frame.
-      void fromString(const std::string str) throw()
+      void fromString(const std::string str) noexcept
       { frame = ReferenceFrame(str).frame; }
 
       /// boolean operator==
-      bool operator==(const ReferenceFrame& right) const throw()
+      bool operator==(const ReferenceFrame& right) const noexcept
       { return frame == right.frame; }
 
       /// boolean operator< (used by STL for sorting)
-      bool operator<(const ReferenceFrame& right) const throw()
+      bool operator<(const ReferenceFrame& right) const noexcept
       { return frame < right.frame; }
 
       // the rest follow from Boolean algebra...
       /// boolean operator!=
-      bool operator!=(const ReferenceFrame& right) const throw()
+      bool operator!=(const ReferenceFrame& right) const noexcept
       { return !operator==(right); }
 
       /// boolean operator>=
-      bool operator>=(const ReferenceFrame& right) const throw()
+      bool operator>=(const ReferenceFrame& right) const noexcept
       { return !operator<(right); }
 
       /// boolean operator<=
-      bool operator<=(const ReferenceFrame& right) const throw()
+      bool operator<=(const ReferenceFrame& right) const noexcept
       { return (operator<(right) || operator==(right)); }
 
       /// boolean operator>
-      bool operator>(const ReferenceFrame& right) const throw()
+      bool operator>(const ReferenceFrame& right) const noexcept
       { return (!operator<(right) && !operator==(right)); }
 
    private:

--- a/core/lib/TimeHandling/ANSITime.hpp
+++ b/core/lib/TimeHandling/ANSITime.hpp
@@ -109,7 +109,7 @@ namespace gpstk
 
          /// Virtual Destructor.
       virtual ~ANSITime()
-      throw()
+      noexcept
       {}
          //@}
 

--- a/core/lib/TimeHandling/BDSWeekSecond.hpp
+++ b/core/lib/TimeHandling/BDSWeekSecond.hpp
@@ -69,7 +69,7 @@ namespace gpstk
       }
 
          /// Destructor.
-      ~BDSWeekSecond() throw() {}
+      ~BDSWeekSecond() noexcept {}
 
          // the rest define the week rollover and starting time
 

--- a/core/lib/TimeHandling/Epoch.cpp
+++ b/core/lib/TimeHandling/Epoch.cpp
@@ -81,7 +81,7 @@ namespace gpstk
    std::string Epoch::PRINT_FORMAT("%02m/%02d/%04Y %02H:%02M:%02S");
 
    Epoch& Epoch::setTolerance(double tol)
-      throw()
+      noexcept
    {
       tolerance = tol;
       return *this;
@@ -89,13 +89,13 @@ namespace gpstk
    
       // Default constructor; initializes to current system time.
    Epoch::Epoch(const TimeTag& tt)
-      throw(Epoch::EpochException)
+      noexcept(false)
          : tolerance(EPOCH_TOLERANCE)
    {
       set(tt);
    }
    Epoch::Epoch(const CommonTime& ct)
-      throw()
+      noexcept
          : core(ct),
            tolerance(EPOCH_TOLERANCE)
    {}
@@ -105,7 +105,7 @@ namespace gpstk
        */
    Epoch::Epoch(const WeekSecond& tt,
                 short year)
-      throw(Epoch::EpochException)
+      noexcept(false)
          : tolerance(EPOCH_TOLERANCE)
    {
       set(tt, year);
@@ -115,14 +115,14 @@ namespace gpstk
       // @param z GPSZcount object to set to
       // @param f Time frame (see #TimeFrame)
    Epoch::Epoch(const GPSZcount& z)
-      throw()
+      noexcept
          : tolerance(EPOCH_TOLERANCE)
    {
       set(z);
    }
 
    Epoch::operator GPSZcount() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -140,14 +140,14 @@ namespace gpstk
 
       // Copy constructor
    Epoch::Epoch(const Epoch& right)
-      throw()
+      noexcept
          : core(right.core),
            tolerance(right.tolerance)
    {}
 
       // Assignment operator.
    Epoch& Epoch::operator=(const Epoch& right)
-      throw()
+      noexcept
    {
       core = right.core;
       tolerance = right.tolerance;
@@ -158,7 +158,7 @@ namespace gpstk
       // @param right Epoch to subtract from this one.
       // @return difference in seconds.
    double Epoch::operator-(const Epoch& right) const
-      throw()
+      noexcept
    {
       return core - right.core;
    }
@@ -167,7 +167,7 @@ namespace gpstk
       // @param seconds Number of seconds to increase this time by.
       // @return The new time incremented by \c seconds.
    Epoch Epoch::operator+(double seconds) const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return Epoch(*this).addSeconds(seconds);
    }
@@ -176,7 +176,7 @@ namespace gpstk
       // @param seconds Number of seconds to decrease this time by.
       // @return The new time decremented by \c seconds.
    Epoch Epoch::operator-(double seconds) const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return Epoch(*this).addSeconds(-seconds);
    }
@@ -184,7 +184,7 @@ namespace gpstk
       // Add seconds to this time.
       // @param seconds Number of seconds to increase this time by.
    Epoch& Epoch::operator+=(double seconds)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return addSeconds(seconds);
    }
@@ -192,7 +192,7 @@ namespace gpstk
       // Subtract seconds from this time.
       // @param sec Number of seconds to decrease this time by.
    Epoch& Epoch::operator-=(double seconds)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return addSeconds(-seconds);
    }
@@ -200,7 +200,7 @@ namespace gpstk
       // Add seconds to this object.
       // @param seconds Number of seconds to add
    Epoch& Epoch::addSeconds(double seconds)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -217,7 +217,7 @@ namespace gpstk
       // Add (integer) seconds to this object.
       // @param seconds Number of seconds to add.
    Epoch& Epoch::addSeconds(long seconds)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -234,7 +234,7 @@ namespace gpstk
       // Add (integer) milliseconds to this object.
       // @param msec Number of milliseconds to add.
    Epoch& Epoch::addMilliSeconds(long msec)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -251,7 +251,7 @@ namespace gpstk
       // Add (integer) microseconds to this object.
       // @param usec Number of microseconds to add.
    Epoch& Epoch::addMicroSeconds(long usec)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -271,7 +271,7 @@ namespace gpstk
 
       // Equality operator.
    bool Epoch::operator==(const Epoch &right) const 
-      throw()
+      noexcept
    {
       // use the smaller of the two tolerances for comparison
       return (ABS(operator-(right)) <=
@@ -280,14 +280,14 @@ namespace gpstk
 
       // Inequality operator.
    bool Epoch::operator!=(const Epoch &right) const 
-      throw()
+      noexcept
    {
       return !(operator==(right));
    }
 
       // Comparison operator (less-than).
    bool Epoch::operator<(const Epoch &right) const 
-      throw()
+      noexcept
    {
       return (operator-(right) <
             -((tolerance > right.tolerance) ? right.tolerance : tolerance));
@@ -295,7 +295,7 @@ namespace gpstk
 
       // Comparison operator (greater-than).
    bool Epoch::operator>(const Epoch &right) const 
-      throw()
+      noexcept
    {
       return (operator-(right) >
             ((tolerance > right.tolerance) ? right.tolerance : tolerance));
@@ -303,26 +303,26 @@ namespace gpstk
    
       // Comparison operator (less-than or equal-to).
    bool Epoch::operator<=(const Epoch &right) const 
-      throw()
+      noexcept
    {
       return !(operator>(right));
    }
 
       // Comparison operator (greater-than or equal-to).
    bool Epoch::operator>=(const Epoch &right) const 
-      throw()
+      noexcept
    {
       return !(operator<(right));
    }
 
    Epoch::operator CommonTime() const
-      throw()
+      noexcept
    {
       return core;
    }
 
    Epoch& Epoch::set(const TimeTag& tt)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -337,7 +337,7 @@ namespace gpstk
    }
 
    Epoch& Epoch::set(const WeekSecond& tt, short year)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       WeekSecond& ws = const_cast<WeekSecond&>(tt);
       ws.adjustToYear(year);
@@ -346,7 +346,7 @@ namespace gpstk
    }
 
    Epoch& Epoch::set(const CommonTime& c)
-      throw()
+      noexcept
    {
       core = c;
       return *this;
@@ -359,7 +359,7 @@ namespace gpstk
       // @param f Time frame (see #TimeFrame)
       // @return a reference to this object.
    Epoch& Epoch::set(const GPSZcount& z)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -377,7 +377,7 @@ namespace gpstk
    }
 
    Epoch& Epoch::setTime(const CommonTime& ct)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -396,7 +396,7 @@ namespace gpstk
    }
    
    Epoch& Epoch::setDate(const CommonTime& ct)
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       try
       {
@@ -416,7 +416,7 @@ namespace gpstk
    
       // set using local time
    Epoch& Epoch::setLocalTime()
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       time_t t;
       time(&t);
@@ -432,7 +432,7 @@ namespace gpstk
 
    Epoch& Epoch::scanf(const string& str,
                        const string& fmt)
-      throw(StringException, InvalidRequest)
+      noexcept(false)
    {
       try
       {
@@ -447,7 +447,7 @@ namespace gpstk
 
       // Format this time into a string.
    string Epoch::printf(const string& fmt) const
-      throw(StringException)
+      noexcept(false)
    {
       try
       {

--- a/core/lib/TimeHandling/Epoch.hpp
+++ b/core/lib/TimeHandling/Epoch.hpp
@@ -171,12 +171,12 @@ namespace gpstk
          //@{
          /// Changes the EPOCH_TOLERANCE for all Epoch objects
       static double setEpochTolerance(double tol)
-         throw()
+         noexcept
       { return EPOCH_TOLERANCE = tol; }
 
          /// Returns the current EPOCH_TOLERANCE.
       static double getEpochTolerance()
-         throw()
+         noexcept
       { return EPOCH_TOLERANCE; }
    
          /**
@@ -187,13 +187,13 @@ namespace gpstk
           * @sa Epoch-Specific Definitions
           */
       Epoch& setTolerance(double tol)
-         throw();
+         noexcept;
 
          /** 
           * Return the tolerance value currently in use by this object.
           * @return the current tolerance value (in seconds, of course)
           */
-      double getTolerance() const throw()
+      double getTolerance() const noexcept
       { return tolerance; }
          //@}
 
@@ -211,14 +211,14 @@ namespace gpstk
           * GPS full week and second (GPSWeekSecond)
           */
       Epoch(const TimeTag& tt = SystemTime())
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * CommonTime Constructor.
           * Set the time using the given CommonTime object.
           */
       Epoch(const CommonTime& ct)
-         throw();
+         noexcept;
 
          /** 
           * TimeTag + Year Constructor.
@@ -231,13 +231,13 @@ namespace gpstk
           */
       Epoch(const WeekSecond& tt,
             short year)
-         throw(EpochException);
+         noexcept(false);
 
          /** GPSZcount Constructor.
           * Set the current time using the given GPSZcount.
           */
       Epoch(const GPSZcount& gzc)
-         throw();
+         noexcept;
       
          // Other Constructors:
          // gps 29-bit zcount w/ epoch determined by current system time
@@ -245,7 +245,7 @@ namespace gpstk
 
          /// Destructor.
       ~Epoch()
-         throw()
+         noexcept
       {}
          //@}
 
@@ -253,11 +253,11 @@ namespace gpstk
          //@{
          /// Copy constructor.
       Epoch(const Epoch &right)
-         throw();
+         noexcept;
 
          /// Assignment operator.
       Epoch& operator=(const Epoch& right)
-         throw();
+         noexcept;
          //@}
       
          /// @name Arithmetic
@@ -268,7 +268,7 @@ namespace gpstk
           * @return difference in seconds.
           */
       double operator-(const Epoch& right) const
-         throw();
+         noexcept;
 
          /**
           * Add seconds to this time.
@@ -276,7 +276,7 @@ namespace gpstk
           * @return The new time incremented by \c sec.
           */
       Epoch operator+(double sec) const
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Subtract seconds from this time.
@@ -284,7 +284,7 @@ namespace gpstk
           * @return The new time decremented by \c sec.
           */
       Epoch operator-(double sec) const
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Add seconds to this time.
@@ -292,7 +292,7 @@ namespace gpstk
           * @throws EpochException on over/under-flow
           */
       Epoch& operator+=(double sec)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Subtract seconds from this time.
@@ -300,7 +300,7 @@ namespace gpstk
           * @throws EpochException on over/under-flow
           */
       Epoch& operator-=(double sec)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Add (double) seconds to this time.
@@ -308,7 +308,7 @@ namespace gpstk
           * @throws EpochException on over/under-flow
           */
       Epoch& addSeconds(double seconds)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Add (integer) seconds to this time.
@@ -316,7 +316,7 @@ namespace gpstk
           * @throws EpochException on over/under-flow
           */
       Epoch& addSeconds(long seconds)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Add (integer) milliseconds to this time.
@@ -324,7 +324,7 @@ namespace gpstk
           * @throws EpochException on over/under-flow
           */
       Epoch& addMilliSeconds(long msec)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Add (integer) microseconds to this time.
@@ -332,23 +332,23 @@ namespace gpstk
           * @throws EpochException on over/under-flow
           */
       Epoch& addMicroSeconds(long usec)
-         throw(EpochException);
+         noexcept(false);
          //@}
 
          /// @name Comparisons
          //@{
       bool operator==(const Epoch &right) const
-         throw();
+         noexcept;
       bool operator!=(const Epoch &right) const
-         throw();
+         noexcept;
       bool operator<(const Epoch &right) const
-         throw();
+         noexcept;
       bool operator>(const Epoch &right) const
-         throw();
+         noexcept;
       bool operator<=(const Epoch &right) const
-         throw();
+         noexcept;
       bool operator>=(const Epoch &right) const
-         throw();
+         noexcept;
          //@}
 
          /// @name Accessor Methods (get and set)
@@ -358,67 +358,67 @@ namespace gpstk
          /// TimeTag type.
       template <class TimeTagType>
       TimeTagType get() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get Julian Date JD
          /// @Warning For some compilers, this result may have diminished
          ///  accuracy.
       inline long double JD() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get Modified Julian Date MJD
          /// @Warning For some compilers, this result may have diminished
          ///  accuracy.
       inline long double MJD() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get year.
       inline short year() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get month of year.
       inline short month() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get day of month.
       inline short day() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get day of week
       inline short dow() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get hour of day.
       inline short hour() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get minutes of hour.
       inline short minute() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get seconds of minute.
       inline double second() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get seconds of day.
       inline double sod() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get 10-bit GPS week
       inline short GPSModWeek() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get 10-bit GPS week, deprecated, use GPSModWeek()
       inline short GPSweek10() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get normal (19 bit) zcount.
       inline long GPSzcount() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Same as GPSzcount() but without rounding to nearest zcount.
       inline long GPSzcountFloor() const
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Get time as 32 bit Z count.
@@ -426,77 +426,77 @@ namespace gpstk
           * week in Zcounts.
           */
       inline unsigned long GPSzcount32() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Same as fullZcount() but without rounding to nearest zcount.
       inline unsigned long GPSzcount32Floor() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get GPS second of week.
       inline double GPSsow() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get full (>10 bits) week 
       inline short GPSweek() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get BDS second of week.
       inline double BDSsow() const
-         throw(EpochException);
+         noexcept(false);
    
          /// Get full BDS week 
       inline short BDSweek() const
-         throw(EpochException);
+         noexcept(false);
    
          /// Get mod (short) BDS week
       inline short BDSModWeek() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get QZS second of week.
       inline double QZSsow() const
-         throw(EpochException);
+         noexcept(false);
    
          /// Get full QZS week 
       inline short QZSweek() const
-         throw(EpochException);
+         noexcept(false);
    
          /// Get mod (short) QZS week
       inline short QZSModWeek() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get GAL second of week.
       inline double GALsow() const
-         throw(EpochException);
+         noexcept(false);
    
          /// Get full GAL week 
       inline short GALweek() const
-         throw(EpochException);
+         noexcept(false);
    
          /// Get mod (short) GAL week
       inline short GALModWeek() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get day of year.
       inline short doy() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get object time as a (long double) modified Julian date.
          /// @Warning For some compilers, this result may have diminished
          ///  accuracy.
       inline long double getMJDasLongDouble() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Get object time in UNIX timeval structure.
       inline struct timeval unixTime() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Convert this object to a GPSZcount object.
       operator GPSZcount() const
-         throw(EpochException);
+         noexcept(false);
 
          /// Convert this object to a CommonTime object.
       operator CommonTime() const
-         throw();
+         noexcept;
 
          /// @todo Could we get away with just CommonTime sets? The TimeTags
          /// can convert themselves to CommonTime objects.  That's what we
@@ -508,7 +508,7 @@ namespace gpstk
           * @return a reference to this object.
           */
       Epoch& set(const TimeTag& tt = SystemTime())
-         throw(EpochException);
+         noexcept(false);
       
          /** Set the object using a TimeTag and a year as a hint.
           * @param tt the TimeTag to which to set this object.
@@ -517,7 +517,7 @@ namespace gpstk
           */
       Epoch& set(const WeekSecond& tt,
                  short year)
-         throw(EpochException);
+         noexcept(false);
       
          /**
           * Set the object using the give CommonTime.
@@ -525,13 +525,13 @@ namespace gpstk
           * @return a reference to this object.
           */
       Epoch& set(const CommonTime& c)
-         throw();
+         noexcept;
 
          /**
           * Set the object using a GPSZcount object.
           */
       Epoch& set(const GPSZcount& z)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Set the object's time using a CommonTime object. This operation
@@ -540,7 +540,7 @@ namespace gpstk
           * objects, this method works for them as well.
           */
       Epoch& setTime(const CommonTime& ct)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Set the object's date using a CommonTime object. This operation
@@ -549,14 +549,14 @@ namespace gpstk
           * objects, this method works for them as well.
           */
       Epoch& setDate(const CommonTime& ct)
-         throw(EpochException);
+         noexcept(false);
 
          /**
           * Set the object time to the current local time.
           * @todo What is this?
           */
       Epoch& setLocalTime()
-         throw(EpochException);
+         noexcept(false);
 
          // other sets:
          // ymdhms
@@ -638,7 +638,7 @@ namespace gpstk
           */
       Epoch& scanf(const std::string& str, 
                    const std::string& fmt)
-         throw(StringUtils::StringException, InvalidRequest);
+         noexcept(false);
 
          // if you can see this, ignore the \'s below, as they are for
          // the nasty html-ifying of doxygen.  Browsers try and
@@ -699,7 +699,7 @@ namespace gpstk
           * representation specified by \c fmt.
           */
       std::string printf(const std::string& fmt = PRINT_FORMAT) const
-         throw(StringUtils::StringException);
+         noexcept(false);
          //@}
 
    private:
@@ -727,7 +727,7 @@ namespace gpstk
 
 
    template <class TimeTagType>
-   TimeTagType Epoch::get() const throw(EpochException)
+   TimeTagType Epoch::get() const noexcept(false)
    {
       try { return TimeTagType(core); }
       catch( Exception& e)
@@ -741,7 +741,7 @@ namespace gpstk
       /// @warning For some compilers, this result may have diminished 
       /// accuracy.
    long double Epoch::JD() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<JulianDate>().jd;
    }
@@ -750,91 +750,91 @@ namespace gpstk
       /// @warning For some compilers, this result may have diminished 
       /// accuracy.
    long double Epoch::MJD() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<gpstk::MJD>().mjd;    // gpstk to distinguish from Epoch::MJD
    }
    
       /// Get year.
    short Epoch::year() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<CivilTime>().year);
    }
    
       /// Get month of year.
    short Epoch::month() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<CivilTime>().month);
    }
    
       /// Get day of month.
    short Epoch::day() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<CivilTime>().day);
    }
    
       /// Get day of week
    short Epoch::dow() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return (((static_cast<long>(JD()) % 7) + 1) % 7) ;
    }
    
       /// Get hour of day.
    short Epoch::hour() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<CivilTime>().hour);
    }
    
       /// Get minutes of hour.
    short Epoch::minute() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<CivilTime>().minute);
    }
    
       /// Get seconds of minute.
    double Epoch::second() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<CivilTime>().second;
    }
    
       /// Get seconds of day.
    double Epoch::sod() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<YDSTime>().sod;
    }
    
       /// Get 10-bit GPS week. Deprecated, used GPSModWeek()
    short Epoch::GPSweek10() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return GPSModWeek();
    }
 
       /// Get 10-bit GPS week
    short Epoch::GPSModWeek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<GPSWeekSecond>().getModWeek());
    }
    
       /// Get normal (19 bit) zcount.
    long Epoch::GPSzcount() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<GPSWeekZcount>().zcount;
    }
    
       /// Same as GPSzcount() but without rounding to nearest zcount.
    long Epoch::GPSzcountFloor() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       Epoch e = *this + .75; // add half a zcount
       return e.get<GPSWeekZcount>().zcount;
@@ -844,14 +844,14 @@ namespace gpstk
       /// The 13 MSBs are week modulo 1024, 19 LSBs are seconds of
       /// week in Zcounts.
    unsigned long Epoch::GPSzcount32() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<GPSWeekZcount>().getZcount32();
    }
    
       /// Same as fullZcount() but without rounding to nearest zcount.
    unsigned long Epoch::GPSzcount32Floor() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       Epoch e = *this + .75; // add half a zcount
       return e.get<GPSWeekZcount>().getZcount32();
@@ -859,91 +859,91 @@ namespace gpstk
    
       /// Get GPS second of week.
    double Epoch::GPSsow() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<GPSWeekSecond>().sow;
    }
    
       /// Get full (>10 bits) week 
    short Epoch::GPSweek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<GPSWeekSecond>().week);
    }
    
       /// Get BDS second of week.
    double Epoch::BDSsow() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<BDSWeekSecond>().sow;
    }
    
       /// Get full BDS week 
    short Epoch::BDSweek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<BDSWeekSecond>().week);
    }
    
       /// Get mod (short) BDS week
    short Epoch::BDSModWeek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<BDSWeekSecond>().getModWeek());
    }
    
       /// Get QZS second of week.
    double Epoch::QZSsow() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<QZSWeekSecond>().sow;
    }
    
       /// Get full QZS week 
    short Epoch::QZSweek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<QZSWeekSecond>().week);
    }
    
       /// Get mod (short) QZS week
    short Epoch::QZSModWeek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<QZSWeekSecond>().getModWeek());
    }
    
       /// Get GAL second of week.
    double Epoch::GALsow() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<GALWeekSecond>().sow;
    }
    
       /// Get full GAL week 
    short Epoch::GALweek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<GALWeekSecond>().week);
    }
    
       /// Get mod (short) GAL week
    short Epoch::GALModWeek() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<GALWeekSecond>().getModWeek());
    }
    
       /// Get day of year.
    short Epoch::doy() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return static_cast<short>(get<YDSTime>().doy);
    }
    
       /// Get object time in UNIX timeval structure.
    struct timeval Epoch::unixTime() const
-      throw(Epoch::EpochException)
+      noexcept(false)
    {
       return get<UnixTime>().tv;
    }

--- a/core/lib/TimeHandling/EpochDataStore.cpp
+++ b/core/lib/TimeHandling/EpochDataStore.cpp
@@ -144,7 +144,7 @@ namespace gpstk
        *     cannot be found in the map.
        */
    std::vector<double> EpochDataStore::getData(const CommonTime& t) const
-         throw(InvalidRequest)
+         noexcept(false)
    {
       // check the time
       if( (t < initialTime) || (t > finalTime))

--- a/core/lib/TimeHandling/EpochDataStore.hpp
+++ b/core/lib/TimeHandling/EpochDataStore.hpp
@@ -142,7 +142,7 @@ namespace gpstk
           *     cannot be found in the map.
           */
       std::vector<double> getData(const CommonTime& t) const
-         throw(InvalidRequest);
+         noexcept(false);
 
       
          /// Object holding all the data for the vehicle

--- a/core/lib/TimeHandling/GALWeekSecond.hpp
+++ b/core/lib/TimeHandling/GALWeekSecond.hpp
@@ -58,7 +58,7 @@ namespace gpstk
          /// Constructor.
       GALWeekSecond(unsigned int w = 0,
                     double s = 0.,
-                    TimeSystem ts = TimeSystem::GAL) throw()
+                    TimeSystem ts = TimeSystem::GAL) noexcept
             : WeekSecond(w,s)
       { timeSystem = ts; }
 
@@ -69,7 +69,7 @@ namespace gpstk
       }
 
          /// Destructor.
-      ~GALWeekSecond() throw() {}
+      ~GALWeekSecond() noexcept {}
       
          /// Return the number of bits in the bitmask used to get the ModWeek from the
          /// full week.

--- a/core/lib/TimeHandling/GPSWeekZcount.cpp
+++ b/core/lib/TimeHandling/GPSWeekZcount.cpp
@@ -224,7 +224,7 @@ namespace gpstk
 
 
    GPSWeekZcount& GPSWeekZcount::addWeeks(short inWeeks)
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       week += inWeeks;
       if (week < 0)
@@ -237,7 +237,7 @@ namespace gpstk
 
 
    GPSWeekZcount& GPSWeekZcount::addZcounts(long inZcounts)
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       if (inZcounts == 0)
          return *this;
@@ -288,7 +288,7 @@ namespace gpstk
 
 
    GPSWeekZcount GPSWeekZcount::operator++(int)
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       GPSWeekZcount temp = *this;
       ++(*this);
@@ -297,14 +297,14 @@ namespace gpstk
 
 
    GPSWeekZcount& GPSWeekZcount::operator++()
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       return addZcounts(1);
    }
 
 
    GPSWeekZcount GPSWeekZcount::operator--(int)
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       GPSWeekZcount temp = *this;
       --(*this);
@@ -313,28 +313,28 @@ namespace gpstk
 
 
    GPSWeekZcount& GPSWeekZcount::operator--()
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       return addZcounts(-1);
    }
 
 
    GPSWeekZcount GPSWeekZcount::operator+(long inZcounts) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       return GPSWeekZcount(*this).addZcounts(inZcounts);
    }
 
 
    GPSWeekZcount GPSWeekZcount::operator-(long inZcounts) const
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       return operator+(-inZcounts);
    }
 
 
    long GPSWeekZcount::operator-(const GPSWeekZcount& right) const
-      throw()
+      noexcept
    {
       return (((long(week) - long(right.week)) * ZCOUNT_PER_WEEK) +
               (long(zcount) - long(right.zcount)));
@@ -342,14 +342,14 @@ namespace gpstk
 
 
    GPSWeekZcount& GPSWeekZcount::operator+=(long inZcounts)
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       return addZcounts(inZcounts);
    }
 
 
    GPSWeekZcount& GPSWeekZcount::operator-=(long inZcounts)
-      throw(gpstk::InvalidRequest)
+      noexcept(false)
    {
       return addZcounts(-inZcounts);
    }
@@ -358,7 +358,7 @@ namespace gpstk
    bool GPSWeekZcount::inSameTimeBlock(const GPSWeekZcount& other,
                                        unsigned long inZcountBlock,
                                        unsigned long inZcountOffset)
-      throw()
+      noexcept
    {
       if (inZcountBlock < ZCOUNT_PER_WEEK)
       {

--- a/core/lib/TimeHandling/GPSWeekZcount.hpp
+++ b/core/lib/TimeHandling/GPSWeekZcount.hpp
@@ -240,7 +240,7 @@ namespace gpstk
           * @return weeks * ZCOUNT_PER_WEEK + zcount
           */
       unsigned long getTotalZcounts() const
-         throw()
+         noexcept
       { return (unsigned long)week * ZCOUNT_PER_WEEK + zcount; }
 
          /** Add the given number of weeks to the current value.
@@ -249,7 +249,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inWeeks would
           *   render this object invalid. */
       GPSWeekZcount& addWeeks(short inWeeks)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Add the given number of Z-counts to the current value.
           * This may cause a roll-(over/under) of the Z-count and
@@ -260,7 +260,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount& addZcounts(long inZcounts)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Postfix increment the Z-count in this object (x++).  This
           * may also cause the roll-over of the Z-count and
@@ -270,7 +270,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount operator++(int)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Prefix increment the Z-count in this object (++x). This
           * may also cause the roll-over of the Z-count and
@@ -279,7 +279,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount& operator++()
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Postfix decrement the Z-count in this object (x--).  This
           * may also cause the roll-under of the Z-count and
@@ -289,7 +289,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if a Z-count decrement would
           *   render this object invalid. */
       GPSWeekZcount operator--(int)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Prefix decrement the Z-count in this object (--x). This
           * may also cause the roll-under of the Z-count and
@@ -298,7 +298,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if a Z-count decrement would
           *   render this object invalid. */
       GPSWeekZcount& operator--()
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Add the given number of Z-counts to the current value.
           * This may cause a roll-(over/under) of the Z-count and
@@ -309,7 +309,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount operator+(long inZcounts) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Subtract the given number of Z-counts to the current value.
           * This may cause a roll-(over/under) of the Z-count and
@@ -320,13 +320,13 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount operator-(long inZcounts) const
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Compute the time difference between this object and \a right.
           * @param[in] right the GPSWeekZcount to subtract from this object.
           * @return the number of Z-counts between this object and \a right */
       long operator-(const GPSWeekZcount& right) const
-         throw();
+         noexcept;
 
          /** Add the given number of Z-counts to the current value.
           * This may cause a roll-(over/under) of the Z-count and
@@ -337,7 +337,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount& operator+=(long inZcounts)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /** Subtract the given number of Z-counts to the current value.
           * This may cause a roll-(over/under) of the Z-count and
@@ -348,7 +348,7 @@ namespace gpstk
           * @throw gpstk::InvalidRequest if adding inZcounts would
           *   render this object invalid. */
       GPSWeekZcount& operator-=(long inZcounts)
-         throw(gpstk::InvalidRequest);
+         noexcept(false);
 
          /**
           * This is a test of whether or not this object and the given
@@ -374,7 +374,7 @@ namespace gpstk
       bool inSameTimeBlock(const GPSWeekZcount& other,
                            unsigned long inZcountBlock,
                            unsigned long inZcountOffset = 0)
-         throw();
+         noexcept;
 
       unsigned int zcount;
    };

--- a/core/lib/TimeHandling/IRNWeekSecond.hpp
+++ b/core/lib/TimeHandling/IRNWeekSecond.hpp
@@ -69,7 +69,7 @@ namespace gpstk
       }
 
          /// Destructor.
-      ~IRNWeekSecond() throw() {}
+      ~IRNWeekSecond() noexcept {}
 
          // the rest define the week rollover and starting time
 

--- a/core/lib/TimeHandling/TimeRange.cpp
+++ b/core/lib/TimeHandling/TimeRange.cpp
@@ -56,7 +56,7 @@ namespace gpstk
                 const CommonTime& startDT, 
                 const CommonTime& endDT,
                 const bool startInclusive, 
-                const bool endInclusive ) throw(TimeRangeException)
+                const bool endInclusive ) noexcept(false)
    {
       try
       {
@@ -71,7 +71,7 @@ namespace gpstk
    
    TimeRange::TimeRange( DTPair dtPair,
                 const bool startInclusive, 
-                const bool endInclusive ) throw(TimeRangeException)
+                const bool endInclusive ) noexcept(false)
    {
       try
       {
@@ -91,7 +91,7 @@ namespace gpstk
    void TimeRange::init( const CommonTime& startDT, 
                     const CommonTime& endDT,
                     const bool startInclusive, 
-                    const bool endInclusive ) throw(TimeRangeException)
+                    const bool endInclusive ) noexcept(false)
    {
       if (endDT<startDT)
       {
@@ -118,7 +118,7 @@ namespace gpstk
    void TimeRange::set( const CommonTime& startDT, 
                 const CommonTime& endDT,
                 const bool startInclusive, 
-                const bool endInclusive ) throw(TimeRangeException)
+                const bool endInclusive ) noexcept(false)
    {
       try
       {
@@ -271,8 +271,7 @@ namespace gpstk
       // Formatted input
    TimeRange& TimeRange::setToString( const string& str, 
                                       const string& fmt)
-         throw(TimeRangeException, 
-               StringUtils::StringException)
+         noexcept(false)
    {
          // Ignore leading whitespace.  
          // See if first non-whitespace character is '[' or '('
@@ -374,7 +373,7 @@ namespace gpstk
 
       // Formatted output
    std::string TimeRange::printf(const std::string formatArg) const
-        throw(gpstk::StringUtils::StringException)
+        noexcept(false)
    {
       string out;
 

--- a/core/lib/TimeHandling/TimeRange.hpp
+++ b/core/lib/TimeHandling/TimeRange.hpp
@@ -67,12 +67,12 @@ namespace gpstk
       TimeRange(const CommonTime& startDT, 
                 const CommonTime& endDT,
                 const bool startInclusive=true, 
-                const bool endInclusive=true ) throw(TimeRangeException);
+                const bool endInclusive=true ) noexcept(false);
 
          /// To cover potential use with RiseSetTimeList               
       TimeRange( DTPair dtPair,
                 const bool startInclusive=true, 
-                const bool endInclusive=true ) throw(TimeRangeException); 
+                const bool endInclusive=true ) noexcept(false); 
 
          /// Copy construtor       
       TimeRange(const TimeRange& tr); 
@@ -86,7 +86,7 @@ namespace gpstk
       void set( const CommonTime& startDT, 
                 const CommonTime& endDT,
                 const bool startInclusive=true, 
-                const bool endInclusive=true ) throw(TimeRangeException);
+                const bool endInclusive=true ) noexcept(false);
 
          /** Return true is testDT is within the TimeRange.  Whether
           * the boundaries are included is in accordance with the
@@ -131,12 +131,11 @@ namespace gpstk
           *  \li followed by an optional ']' or ')' (assume ']').  */
       TimeRange& setToString( const std::string& str, 
                               const std::string& fmt)
-         throw(TimeRangeException, 
-               StringUtils::StringException);
+         noexcept(false);
 
          /// Formatted print
       std::string printf(const std::string formatArg="%02m/%02d/%02y %02H:%02M:%02S" ) const
-        throw(gpstk::StringUtils::StringException);
+        noexcept(false);
 
          /// Dump method.   
       std::string dump(const std::string formatArg="%02m/%02d/%02y %02H:%02M:%02S" ) const;
@@ -150,7 +149,7 @@ namespace gpstk
       void init(const CommonTime& startDT, 
                 const CommonTime& endDT,
                 const bool startInclusive=true, 
-                const bool endInclusive=true ) throw(TimeRangeException);
+                const bool endInclusive=true ) noexcept(false);
 
    };
 

--- a/core/lib/Utilities/BinUtils.hpp
+++ b/core/lib/Utilities/BinUtils.hpp
@@ -331,7 +331,7 @@ namespace gpstk
           *  the end of \a str.
           */
       inline std::string xorChecksum(const std::string& str, unsigned wordSize)
-         throw(gpstk::InvalidParameter);
+         noexcept(false);
 
          //@}
 
@@ -545,7 +545,7 @@ namespace gpstk
       }
 
       std::string xorChecksum(const std::string& str, unsigned wordSize)
-         throw(gpstk::InvalidParameter)
+         noexcept(false)
       {
          size_t strSize = str.size();
          std::string rv(wordSize, 0);

--- a/core/lib/Utilities/StringUtils.hpp
+++ b/core/lib/Utilities/StringUtils.hpp
@@ -170,7 +170,7 @@ namespace gpstk
       std::string& stripLeading(std::string& s,
                                 const std::string& aString,
                                 std::string::size_type num = std::string::npos)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Remove a string from the beginning of another string const version.
@@ -185,7 +185,7 @@ namespace gpstk
       inline std::string stripLeading(const std::string& s,
                                       const std::string& aString,
                                       std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripLeading(t, aString, num); return t; }
 
          /**
@@ -201,7 +201,7 @@ namespace gpstk
       inline std::string& stripLeading(std::string& s,
                                        const char* pString,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return stripLeading(s, std::string(pString), num); }
 
          /**
@@ -217,7 +217,7 @@ namespace gpstk
       inline std::string stripLeading(const std::string& s,
                                       const char* pString,
                                       std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripLeading(t, std::string(pString), num); return t; }
 
          /**
@@ -233,7 +233,7 @@ namespace gpstk
       inline std::string& stripLeading(std::string& s,
                                        const char aCharacter,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return stripLeading(s, std::string(1,aCharacter), num); }
 
          /**
@@ -249,7 +249,7 @@ namespace gpstk
       inline std::string stripLeading(const std::string& s,
                                       const char aCharacter,
                                       std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripLeading(t, std::string(1,aCharacter), num); return t; }
 
          /**
@@ -263,7 +263,7 @@ namespace gpstk
           */
       inline std::string& stripLeading(std::string& s,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return stripLeading(s,std::string(1,' '),num); }
 
          /**
@@ -277,7 +277,7 @@ namespace gpstk
           */
       inline std::string stripLeading(const std::string& s,
                                       std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripLeading(t,std::string(1,' '),num); return t; }
 
          /**
@@ -293,7 +293,7 @@ namespace gpstk
       inline std::string& stripTrailing(std::string& s,
                                         const std::string& aString,
                                         std::string::size_type num = std::string::npos)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Remove a string from the end of another string const version.
@@ -308,7 +308,7 @@ namespace gpstk
       inline std::string stripTrailing(const std::string& s,
                                        const std::string& aString,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripTrailing(t, aString, num); return t;}
 
          /**
@@ -324,7 +324,7 @@ namespace gpstk
       inline std::string& stripTrailing(std::string& s,
                                         const char* pString,
                                         std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return stripTrailing(s, std::string(pString), num); }
 
          /**
@@ -340,7 +340,7 @@ namespace gpstk
       inline std::string stripTrailing(const std::string& s,
                                        const char* pString,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripTrailing(t, std::string(pString), num); return t; }
 
          /**
@@ -356,7 +356,7 @@ namespace gpstk
       inline std::string& stripTrailing(std::string& s,
                                         const char aCharacter,
                                         std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return stripTrailing(s, std::string(1,aCharacter), num); }
 
          /**
@@ -372,7 +372,7 @@ namespace gpstk
       inline std::string stripTrailing(const std::string& s,
                                        const char aCharacter,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripTrailing(t, std::string(1,aCharacter), num); return t; }
 
          /**
@@ -386,7 +386,7 @@ namespace gpstk
           */
       inline std::string& stripTrailing(std::string& s,
                                         std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return stripTrailing(s, std::string(1,' '), num); }
 
          /**
@@ -400,7 +400,7 @@ namespace gpstk
           */
       inline std::string stripTrailing(const std::string& s,
                                        std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); stripTrailing(t, std::string(1,' '), num); return t;}
 
          /**
@@ -416,7 +416,7 @@ namespace gpstk
       inline std::string& strip(std::string& s,
                                 const std::string& aString,
                                 std::string::size_type num = std::string::npos)
-         throw(StringException);
+         noexcept(false);
 
 
          /**
@@ -432,7 +432,7 @@ namespace gpstk
       inline std::string strip(const std::string& s,
                                const std::string& aString,
                                std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s);  strip(t, aString, num); return t; }
 
 
@@ -449,7 +449,7 @@ namespace gpstk
       inline std::string& strip(std::string& s,
                                 const char* pString,
                                 std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return strip(s, std::string(pString), num); }
 
          /**
@@ -465,7 +465,7 @@ namespace gpstk
       inline std::string strip(const std::string& s,
                                const char* pString,
                                std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); strip(t, std::string(pString), num); return t; }
 
          /**
@@ -481,7 +481,7 @@ namespace gpstk
       inline std::string& strip(std::string& s,
                                 const char aCharacter,
                                 std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return strip(s, std::string(1,aCharacter), num); }
 
          /**
@@ -497,7 +497,7 @@ namespace gpstk
       inline std::string strip(const std::string& s,
                                const char aCharacter,
                                std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s);  strip(t, std::string(1,aCharacter), num); return t;}
 
          /**
@@ -511,7 +511,7 @@ namespace gpstk
           */
       inline std::string& strip(std::string& s,
                                 std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { return strip(s, std::string(1, ' '), num); }
 
          /**
@@ -525,7 +525,7 @@ namespace gpstk
           */
       inline std::string strip(const std::string& s,
                                std::string::size_type num = std::string::npos)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s);  strip(t, std::string(1, ' '), num); return t;}
 
          /**
@@ -608,7 +608,7 @@ namespace gpstk
       inline std::string& rightJustify(std::string& s,
                                        const std::string::size_type length,
                                        const char pad = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Right-justifies the receiver in a string of the specified
@@ -624,7 +624,7 @@ namespace gpstk
       inline std::string rightJustify(const std::string& s,
                                       const std::string::size_type length,
                                       const char pad = ' ')
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); return rightJustify(t, length, pad); }
 
          /**
@@ -641,7 +641,7 @@ namespace gpstk
       inline std::string& leftJustify(std::string& s,
                                       const std::string::size_type length,
                                       const char pad = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Left-justifies the receiver in a string of the specified
@@ -657,7 +657,7 @@ namespace gpstk
       inline std::string leftJustify(const std::string& s,
                                      const std::string::size_type length,
                                      const char pad = ' ')
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); return leftJustify(t, length, pad); }
 
          /**
@@ -680,7 +680,7 @@ namespace gpstk
       inline std::string& center(std::string& s,
                                  const std::string::size_type length,
                                  const char pad = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Change the length of a string by adding to the beginning and end
@@ -703,7 +703,7 @@ namespace gpstk
       inline std::string center(const std::string& s,
                                 const std::string::size_type length,
                                 const char pad = ' ')
-         throw(StringException)
+         noexcept(false)
       { std::string t(s); return center(t, length, pad); }
 
          /**
@@ -736,7 +736,7 @@ namespace gpstk
           * @return single representation of string.
           */
       inline float asFloat(const std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a string to a big precision floating point number.
@@ -744,7 +744,7 @@ namespace gpstk
           * @return long double representation of string.
           */
       inline long double asLongDouble(const std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a value in a string to a type specified by the template
@@ -755,7 +755,7 @@ namespace gpstk
           */
       template <class X>
       inline X asData(const std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a long double to a string in fixed notation.
@@ -793,7 +793,7 @@ namespace gpstk
           * @return reference to modified \a s.
           */
       inline std::string& d2x(std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a decimal string to a hexadecimal string.
@@ -805,7 +805,7 @@ namespace gpstk
           * @return string containing a hexadecimal number.
           */
       inline std::string d2x(const std::string& s)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s);  return d2x(t); }
 
          /**
@@ -817,7 +817,7 @@ namespace gpstk
           * @return reference to modified \a s.
           */
       inline std::string& x2d(std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a hexadecimal string to a decimal string.
@@ -829,7 +829,7 @@ namespace gpstk
           * @return string containing a hexadecimal number.
           */
       inline std::string x2d(const std::string& s)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s);  return x2d(t); }
 
          /**
@@ -840,7 +840,7 @@ namespace gpstk
           * @return reference to modified \a s.
           */
       inline std::string& c2x(std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a character string to a hexadecimal string.
@@ -848,7 +848,7 @@ namespace gpstk
           * @return string containing a sequence of hexadecimal numbers.
           */
       inline std::string c2x(const std::string& s)
-         throw(StringException)
+         noexcept(false)
       { std::string t(s);  return c2x(t); }
 
          /**
@@ -858,7 +858,7 @@ namespace gpstk
           * @return a long holding the value of \a s.
           */
       inline unsigned int x2uint(const std::string& s)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert an int to a string.
@@ -866,7 +866,7 @@ namespace gpstk
           * @return a string with the hex equivalent of i
           */
       inline std::string int2x(const unsigned int& i)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Replace all instances of \a oldString with \a newString in \a s.
@@ -878,7 +878,7 @@ namespace gpstk
       inline std::string& replaceAll(std::string& s,
                                      const std::string& oldString,
                                      const std::string& newString )
-         throw(StringException);
+         noexcept(false);
 
          /**
           * isDigitString is exactly like the C function isDigit
@@ -936,7 +936,7 @@ namespace gpstk
                                  const char zeroOrMore = '*',
                                  const char oneOrMore = '+',
                                  const char anyChar = '.' )
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Perform pattern matching on strings.
@@ -958,7 +958,7 @@ namespace gpstk
                          const char zeroOrMore = '*',
                          const char oneOrMore = '+',
                          const char anyChar = '.' )
-         throw(StringException)
+         noexcept(false)
       { return matches(s, aPattern, zeroOrMore, oneOrMore, anyChar) !=
             std::string(); }
 
@@ -983,7 +983,7 @@ namespace gpstk
                          const char zeroOrMore = '*',
                          const char oneOrMore = '+',
                          const char anyChar = '.' )
-         throw(StringException)
+         noexcept(false)
       { return matches(s, std::string(pPattern),
                        zeroOrMore, oneOrMore, anyChar) !=  std::string(); }
 
@@ -1008,7 +1008,7 @@ namespace gpstk
                                  const std::string& pat,
                                  const std::string& rep,
                                  T to)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Get a substring of a string.
@@ -1019,7 +1019,7 @@ namespace gpstk
                                    const std::string::size_type startPos = 0,
                                    const std::string::size_type length = std::string::npos,
                                    const char pad = ' ' )
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Change all upper-case letters in a string to lower-case.
@@ -1076,7 +1076,7 @@ namespace gpstk
           */
       inline std::string firstWord(const std::string& s,
                                    const char delimiter = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Counts the number of words in \a s and returns it.
@@ -1087,7 +1087,7 @@ namespace gpstk
           */
       inline int numWords(const std::string& s,
                           const char delimiter = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Returns \a numWords words starting with \a firstWord from
@@ -1105,7 +1105,7 @@ namespace gpstk
                                const std::string::size_type firstWord = 0,
                                const std::string::size_type numWords = std::string::npos,
                                const char delimiter = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Returns word number \a wordNum from \a s (if any).
@@ -1120,7 +1120,7 @@ namespace gpstk
       inline std::string word(const std::string& s,
                               const std::string::size_type wordNum = 0,
                               const char delimiter = ' ')
-         throw(StringException)
+         noexcept(false)
       { return words(s, wordNum, 1, delimiter); }
 
          /**
@@ -1133,7 +1133,7 @@ namespace gpstk
           */
       inline std::string stripFirstWord(std::string& s,
                                         const char delimiter = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Split a string \a str into words as defined by \a delimiter.
@@ -1143,7 +1143,7 @@ namespace gpstk
           */
       inline std::vector<std::string> split(const std::string& str,
                                             const char delimiter = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Remove indicated words from the string \a s.
@@ -1164,7 +1164,7 @@ namespace gpstk
                                       const std::string::size_type first = 0,
                                       const std::string::size_type wordsToReplace = std::string::npos,
                                       const char delimiter = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert a double to a scientific notation number.
@@ -1216,7 +1216,7 @@ namespace gpstk
                                   const std::string::size_type length = std::string::npos,
                                   const std::string::size_type expLen = 3,
                                   const bool checkSwitch = true)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert double precision floating point to a string
@@ -1234,7 +1234,7 @@ namespace gpstk
                                   const std::string::size_type length,
                                   const std::string::size_type expLen,
                                   const bool checkSwitch = true)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Convert FORTRAN representation of a double precision
@@ -1258,7 +1258,7 @@ namespace gpstk
           * @param aStr the string to make printable.
           */
       inline std::string printable(const std::string& aStr)
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Nicely expands the input string into several lines, non-const
@@ -1277,7 +1277,7 @@ namespace gpstk
                                       const std::string& firstIndent = "     ",
                                       const std::string::size_type len = 80,
                                       const char wordDelim = ' ')
-         throw(StringException);
+         noexcept(false);
 
          /**
           * Const version of prettyPrint, which nicely expands the
@@ -1296,7 +1296,7 @@ namespace gpstk
                                      const std::string& firstIndent = "     ",
                                      const std::string::size_type len = 80,
                                      const char wordDelim = ' ')
-         throw(StringException)
+         noexcept(false)
       {
          std::string temp(aStr);
          prettyPrint(temp, lineDelim, indent, firstIndent, len, wordDelim);
@@ -1370,7 +1370,7 @@ namespace gpstk
       inline std::string& stripLeading(std::string& s,
                                        const std::string& aString,
                                        std::string::size_type num)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1398,7 +1398,7 @@ namespace gpstk
       inline std::string& stripTrailing(std::string& s,
                                         const std::string& aString,
                                         std::string::size_type num)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1428,7 +1428,7 @@ namespace gpstk
       inline std::string& strip(std::string& s,
                                 const std::string& aString,
                                 std::string::size_type num)
-         throw(StringException)
+         noexcept(false)
       {
          stripLeading(s, aString, num);
          stripTrailing(s, aString, num);
@@ -1504,7 +1504,7 @@ namespace gpstk
       inline std::string& rightJustify(std::string& s,
                                        const std::string::size_type length,
                                        const char pad)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1530,7 +1530,7 @@ namespace gpstk
       inline std::string& leftJustify(std::string& s,
                                       const std::string::size_type length,
                                       const char pad)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1556,7 +1556,7 @@ namespace gpstk
       inline std::string& center(std::string& s,
                                  const std::string::size_type length,
                                  const char pad)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1584,7 +1584,7 @@ namespace gpstk
 
 
       inline float asFloat(const std::string& s)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1601,7 +1601,7 @@ namespace gpstk
       }
 
       inline long double asLongDouble(const std::string& s)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1619,7 +1619,7 @@ namespace gpstk
 
       template <class X>
       inline X asData(const std::string& s)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1659,7 +1659,7 @@ namespace gpstk
 
          // decimal to hex...
       inline std::string& d2x(std::string& s)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1692,7 +1692,7 @@ namespace gpstk
 
          // character to hex...
       inline std::string& c2x(std::string& s)
-         throw(StringException)
+         noexcept(false)
       {
          const char hexDigits[] = "0123456789ABCDEF";
          try
@@ -1726,7 +1726,7 @@ namespace gpstk
          /// @todo Need to find a way to combine this with x2d.
          // hex to a long.
       inline unsigned int x2uint(const std::string& s)
-         throw (StringException)
+         noexcept(false)
       {
          try
          {
@@ -1751,7 +1751,7 @@ namespace gpstk
          /// @todo detecting 0 isn't quite right...
          // hex to decimal
       inline std::string& x2d(std::string& s)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1785,7 +1785,7 @@ namespace gpstk
       }
 
       inline std::string int2x(const unsigned int& i)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1807,7 +1807,7 @@ namespace gpstk
       inline std::string& replaceAll(std::string& s,
                                      const std::string& oldString,
                                      const std::string& newString)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -1895,7 +1895,7 @@ namespace gpstk
                                  const char zeroOrMore,
                                  const char oneOrMore,
                                  const char anyChar)
-         throw(StringException)
+         noexcept(false)
       {
          std::string thisPattern(aPattern);
          std::string thisStr(s);
@@ -1981,7 +1981,7 @@ namespace gpstk
                                         const std::string& pat,
                                         const std::string& rep,
                                         T to)
-         throw(StringException)
+         noexcept(false)
       {
 #if defined(_WIN32) && _MSC_VER >= 1700
 
@@ -2045,7 +2045,7 @@ namespace gpstk
                                    const std::string::size_type startPos,
                                    const std::string::size_type length,
                                    const char pad)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2099,7 +2099,7 @@ namespace gpstk
 
       inline std::string firstWord(const std::string& s,
                                    const char delimiter)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2133,7 +2133,7 @@ namespace gpstk
 
       inline int numWords(const std::string& s,
                           const char delimiter)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2164,7 +2164,7 @@ namespace gpstk
                                const std::string::size_type firstWord,
                                const std::string::size_type numWords,
                                const char delimiter)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2214,7 +2214,7 @@ namespace gpstk
 
       inline std::string stripFirstWord(std::string& s,
                                         const char delimiter)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2237,7 +2237,7 @@ namespace gpstk
 
       inline std::vector<std::string> split(const std::string& str,
                                             const char delimiter)
-         throw(StringException)
+         noexcept(false)
       {
          try {
             std::vector<std::string> rvec;   // vector to return
@@ -2394,7 +2394,7 @@ namespace gpstk
                                       const std::string::size_type first,
                                       const std::string::size_type wordsToReplace,
                                       const char delimiter)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2533,7 +2533,7 @@ namespace gpstk
                                   const std::string::size_type length,
                                   const std::string::size_type expLen,
                                   const bool checkSwitch)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2635,7 +2635,7 @@ namespace gpstk
                                   const std::string::size_type length,
                                   const std::string::size_type expLen,
                                   const bool checkSwitch)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2696,7 +2696,7 @@ namespace gpstk
       }
 
       inline std::string printable(const std::string& aStr)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {
@@ -2745,7 +2745,7 @@ namespace gpstk
                                       const std::string& firstIndent,
                                       const std::string::size_type len,
                                       const char wordDelim)
-         throw(StringException)
+         noexcept(false)
       {
          try
          {

--- a/core/lib/Utilities/ValidType.hpp
+++ b/core/lib/Utilities/ValidType.hpp
@@ -67,15 +67,15 @@ namespace gpstk
       ValidType(const T& v):value(v),valid(true){}
       ValidType():value(0),valid(false){}
       
-      ValidType& operator=(const T& v) throw()
+      ValidType& operator=(const T& v) noexcept
       { this->valid = true; this->value = v; return *this; }
       
-      ValidType& operator+=(const T& r) throw(){value+=r; return *this;}
-      ValidType& operator-=(const T& r) throw(){value-=r; return *this;}
+      ValidType& operator+=(const T& r) noexcept{value+=r; return *this;}
+      ValidType& operator-=(const T& r) noexcept{value-=r; return *this;}
 
          // A conversion operator, will throw an exception if the object
          // is marked invalid
-      operator T() const throw(InvalidValue)
+      operator T() const noexcept(false)
       {
          if (!this->is_valid()) throw InvalidValue();
          return value;
@@ -90,7 +90,7 @@ namespace gpstk
       bool is_valid() const { return valid; }
       T get_value() const { return value; }
 
-      void set_valid(const bool& v) throw()
+      void set_valid(const bool& v) noexcept
       { valid=v; }
 
    private:
@@ -111,7 +111,7 @@ namespace gpstk
 
 
    template <class T>
-   std::ostream& operator<<(std::ostream& s, const ValidType<T>& r) throw()
+   std::ostream& operator<<(std::ostream& s, const ValidType<T>& r) noexcept
    {
       if (r.is_valid())
          s << r.get_value();


### PR DESCRIPTION
Only replace `throw` with `noexcept` and can be compiled with `set(CMAKE_CXX_STANDARD 17)` in CMakeLists.txt.
